### PR TITLE
Change language to path from confusing pathOrFileObject

### DIFF
--- a/Lib/fontParts/test/test_world.py
+++ b/Lib/fontParts/test/test_world.py
@@ -283,17 +283,22 @@ class TestFontList(unittest.TestCase):
 class TestFontOpen(unittest.TestCase):
 
     def setUp(self):
-        font, _ = self.objectGenerator("font")
+        self.font, _ = self.objectGenerator("font")
         self.font_dir = tempfile.mkdtemp()
         self.font_path = os.path.join(self.font_dir, "test.ufo")
-        font.save(self.font_path)
+        self.font.save(self.font_path)
 
     def tearDown(self):
         import shutil
         shutil.rmtree(self.font_dir)
 
-    def test_font_open(self):
+    def test_font_open_path(self):
         OpenFont(self.font_path)
+        
+    def test_font_open_object(self):
+        from fontTools.ufoLib import UFOReader
+        obj = UFOReader(self.font_path)
+        OpenFont(obj)
 
 
 class TestFontShell_RFont(unittest.TestCase):

--- a/Lib/fontParts/test/test_world.py
+++ b/Lib/fontParts/test/test_world.py
@@ -283,10 +283,10 @@ class TestFontList(unittest.TestCase):
 class TestFontOpen(unittest.TestCase):
 
     def setUp(self):
-        self.font, _ = self.objectGenerator("font")
+        font, _ = self.objectGenerator("font")
         self.font_dir = tempfile.mkdtemp()
         self.font_path = os.path.join(self.font_dir, "test.ufo")
-        self.font.save(self.font_path)
+        font.save(self.font_path)
 
     def tearDown(self):
         import shutil

--- a/Lib/fontParts/world.py
+++ b/Lib/fontParts/world.py
@@ -3,7 +3,8 @@ def OpenFont(path, showInterface=True):
     Open font located at **path**. If **showInterface**
     is ``False``, the font should be opened without
     graphical interface. The default for **showInterface**
-    is ``True``.
+    is ``True``. Note: **path** can both be a string representing
+    a file path, or a font object.
 
     ::
 
@@ -12,7 +13,7 @@ def OpenFont(path, showInterface=True):
         font = OpenFont("/path/to/my/font.ufo")
         font = OpenFont("/path/to/my/font.ufo", showInterface=False)
     """
-    return dispatcher["OpenFont"](pathOrObject=path, showInterface=showInterface)
+    return dispatcher["OpenFont"](path=path, showInterface=showInterface)
 
 
 def NewFont(familyName=None, styleName=None, showInterface=True):
@@ -243,7 +244,7 @@ def AllFonts(sortOptions=None):
 
 
 def RFont(path=None, showInterface=True):
-    return dispatcher["RFont"](pathOrObject=path, showInterface=showInterface)
+    return dispatcher["RFont"](path=path, showInterface=showInterface)
 
 
 def RGlyph():
@@ -621,8 +622,8 @@ try:
 
     # OpenFont, RFont
 
-    def _fontshellRFont(pathOrObject=None, showInterface=True):
-        return fontshell.RFont(pathOrObject=pathOrObject, showInterface=showInterface)
+    def _fontshellRFont(path=None, showInterface=True):
+        return fontshell.RFont(pathOrObject=path, showInterface=showInterface)
 
     dispatcher["OpenFont"] = _fontshellRFont
     dispatcher["RFont"] = _fontshellRFont


### PR DESCRIPTION
Fixes some confusion in the documentation and API. Adds test case.