### PR TITLE
Slightly easier test / dev setup on Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,13 @@ fontshell is fontParts for the commandline, implemented with
 `defcon <https://github.com/typesupply/defcon>`__ and is included
 as part of the fontParts package.
 
-To run the test suite, you can do:
+Before you can run the test suite you’ll need to install the test dependencies:
+
+.. code:: sh
+
+    pip install -r dev-requirements.txt
+
+To run the test suite you can do:
 
 .. code:: sh
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
 virtualenv>=15.0
 tox>=2.3
-unittest2==1.1.0
+unittest2
+coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
+-r requirements.txt
 virtualenv>=15.0
 tox>=2.3
+unittest2==1.1.0


### PR DESCRIPTION
Following the install instructions from the default [README.rst](https://github.com/robotools/fontParts/blob/master/README.rst) on the fontParts GitHub home page does not seem to actually work on Python 3 to get a working dev / testing environment. That leads to something like this:

```python
$ python Lib/fontParts/fontshell/test.py
Traceback (most recent call last):
  File "Lib/fontParts/fontshell/test.py", line 1, in <module>
    from fontParts.test import testEnvironment
  File "/tmp/fontParts/Lib/fontParts/test/__init__.py", line 21, in <module>
    from fontParts.test import test_deprecated
  File "/tmp/fontParts/Lib/fontParts/test/test_deprecated.py", line 1, in <module>
    import unittest2 as unittest
```
`unittest2` is not specified in the main `requirements.txt` file. TravisCI does not seem to mind, because both `coverage` and `unittest2` are manually installed during the Travis `installdeps` phase.

The attached edited `dev-requirements.txt` + the updated instructions on the edited `README.rst` seem to work for me on Python 3.7.4.