### PR TITLE
groups are tuples so remove() doesn't work

### DIFF
--- a/documentation/source/objectref/objects/groups.rst
+++ b/documentation/source/objectref/objects/groups.rst
@@ -33,7 +33,7 @@ If one wants to make a change to the group contents, one should do the following
 
     group = list(font.groups["myGroup"])
     group.remove("A")
-    font.groups["myGroup"] = tuple(group)
+    font.groups["myGroup"] = group
 
 Kerning Groups
 ==============

--- a/documentation/source/objectref/objects/groups.rst
+++ b/documentation/source/objectref/objects/groups.rst
@@ -24,16 +24,16 @@ It is important to understand that any changes to the returned group contents wi
 
 ::
 
-    group = font.groups["myGroup"]
+    group = list(font.groups["myGroup"])
     group.remove("A")
 
 If one wants to make a change to the group contents, one should do the following instead:
 
 ::
 
-    group = font.groups["myGroup"]
+    group = list(font.groups["myGroup"])
     group.remove("A")
-    font.groups["myGroup"] = group
+    font.groups["myGroup"] = tuple(group)
 
 Kerning Groups
 ==============


### PR DESCRIPTION
–updated examples for removing a glyph from a group. I converted to a list to use remove() then converted back to tuple. 

If there's a cleaner way to do this feel free to use that instead, but just thought I'd update this to a working example for now since I just hit this issue. Hope this helps!