### PR TITLE
Use normalizeVisualRounding for FontMath rounding

### DIFF
--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1590,10 +1590,6 @@ class BaseGlyph(BaseObject,
         Subclasses may override this method.
         """
         import fontMath
-        from fontMath.mathFunctions import setRoundIntegerFunction
-        from fontTools.misc.fixedTools import otRound
-
-        setRoundIntegerFunction(otRound)
         mathGlyph = fontMath.MathGlyph(None)
         pen = mathGlyph.getPointPen()
         self.drawPoints(pen)
@@ -1767,6 +1763,10 @@ class BaseGlyph(BaseObject,
         """
         Subclasses may override this method.
         """
+        from fontMath.mathFunctions import setRoundIntegerFunction
+
+        setRoundIntegerFunction(normalizers.normalizeVisualRounding)
+        
         minGlyph = minGlyph._toMathGlyph()
         maxGlyph = maxGlyph._toMathGlyph()
         try:

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1590,6 +1590,10 @@ class BaseGlyph(BaseObject,
         Subclasses may override this method.
         """
         import fontMath
+        from fontMath.mathFunctions import setRoundIntegerFunction
+        from fontTools.misc.fixedTools import otRound
+
+        setRoundIntegerFunction(otRound)
         mathGlyph = fontMath.MathGlyph(None)
         pen = mathGlyph.getPointPen()
         self.drawPoints(pen)

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -183,6 +183,10 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         """
         Subclasses may override this method.
         """
+        from fontMath.mathFunctions import setRoundIntegerFunction
+
+        setRoundIntegerFunction(normalizers.normalizeVisualRounding)
+
         mathInfo = self._toMathInfo(guidelines=False)
         mathInfo = mathInfo.round()
         self._fromMathInfo(mathInfo, guidelines=False)
@@ -216,10 +220,6 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         Subclasses may override this method.
         """
         import fontMath
-        from fontMath.mathFunctions import setRoundIntegerFunction
-        from fontTools.misc.fixedTools import otRound
-
-        setRoundIntegerFunction(otRound)
         # A little trickery is needed here because MathInfo
         # handles font level guidelines. Those are not in this
         # object so we temporarily fake them just enough for
@@ -293,6 +293,10 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         """
         Subclasses may override this method.
         """
+        from fontMath.mathFunctions import setRoundIntegerFunction
+
+        setRoundIntegerFunction(normalizers.normalizeVisualRounding)
+
         minInfo = minInfo._toMathInfo()
         maxInfo = maxInfo._toMathInfo()
         result = interpolate(minInfo, maxInfo, factor)

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -216,6 +216,10 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         Subclasses may override this method.
         """
         import fontMath
+        from fontMath.mathFunctions import setRoundIntegerFunction
+        from fontTools.misc.fixedTools import otRound
+
+        setRoundIntegerFunction(otRound)
         # A little trickery is needed here because MathInfo
         # handles font level guidelines. Those are not in this
         # object so we temporarily fake them just enough for

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -171,9 +171,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         import fontMath
         from fontMath.mathFunctions import setRoundIntegerFunction
-        from fontTools.misc.fixedTools import otRound
 
-        setRoundIntegerFunction(otRound)
+        setRoundIntegerFunction(normalizers.normalizeVisualRounding)
         kerningGroupCompatibility = self._testKerningGroupCompatibility(
                                                         minKerning,
                                                         maxKerning,

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -170,6 +170,10 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         Subclasses may override this method.
         """
         import fontMath
+        from fontMath.mathFunctions import setRoundIntegerFunction
+        from fontTools.misc.fixedTools import otRound
+
+        setRoundIntegerFunction(otRound)
         kerningGroupCompatibility = self._testKerningGroupCompatibility(
                                                         minKerning,
                                                         maxKerning,

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1151,6 +1151,35 @@ class TestGlyph(unittest.TestCase):
         self.assertEqual(report.componentsMissingFromGlyph1, ["a", "b"])
         self.assertEqual(report.componentsMissingFromGlyph2, ["x", "y"])
 
+    # -------------
+    # Interpolation
+    # -------------
+
+    def test_interpolate_glyphWidth_without_rounding(self):
+        interpolated, _ = self.objectGenerator("glyph")
+        glyph_min, _ = self.objectGenerator("glyph")
+        glyph_max, _ = self.objectGenerator("glyph")
+        glyph_min.width = 1000
+        glyph_max.width = 2000
+        interpolated.interpolate(0.5154, glyph_min, glyph_max, round=False)
+        self.assertEqual(
+            interpolated.width,
+            1515.4
+        )
+
+    def test_interpolate_glyphWidth_with_rounding(self):
+        interpolated, _ = self.objectGenerator("glyph")
+        glyph_min, _ = self.objectGenerator("glyph")
+        glyph_max, _ = self.objectGenerator("glyph")
+        glyph_min.width = 1000
+        glyph_max.width = 2000
+        interpolated.interpolate(0.5154, glyph_min, glyph_max, round=True)
+        self.assertEqual(
+            interpolated.width,
+            1515
+        )
+
+
     # ---
     # API
     # ---

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -111,23 +111,23 @@ class TestInfo(unittest.TestCase):
     # -------------
 
     def test_interpolate_unitsPerEm_without_rounding(self):
-        interpolated = self.getInfo_generic()
-        info_min = self.getInfo_generic()
-        info_max = self.getInfo_generic()
-        info_max.unitsPerEm = 2000
-        interpolated.interpolate(0.5154, info_min, info_max, round=False)
+        interpolated_font, _ = self.objectGenerator("font")
+        font_min, _ = self.objectGenerator("font")
+        font_max, _ = self.objectGenerator("font")
+        font_max.info.unitsPerEm = 2000
+        interpolated_font.info.interpolate(0.5154, font_min.info, font_max.info, round=False)
         self.assertEqual(
-            info.unitsPerEm,
+            interpolated_font.info.unitsPerEm,
             1515.4
         )
 
     def test_interpolate_unitsPerEm_with_rounding(self):
-        interpolated = self.getInfo_generic()
-        info_min = self.getInfo_generic()
-        info_max = self.getInfo_generic()
-        info_max.unitsPerEm = 2000
-        interpolated.interpolate(0.5154, info_min, info_max, round=True)
+        interpolated_font, _ = self.objectGenerator("font")
+        font_min, _ = self.objectGenerator("font")
+        font_max, _ = self.objectGenerator("font")
+        font_max.info.unitsPerEm = 2000
+        interpolated_font.info.interpolate(0.5154, font_min.info, font_max.info, round=True)
         self.assertEqual(
-            info.unitsPerEm,
+            interpolated_font.info.unitsPerEm,
             1515
         )

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -114,6 +114,7 @@ class TestInfo(unittest.TestCase):
         interpolated_font, _ = self.objectGenerator("font")
         font_min, _ = self.objectGenerator("font")
         font_max, _ = self.objectGenerator("font")
+        font_min.info.unitsPerEm = 1000
         font_max.info.unitsPerEm = 2000
         interpolated_font.info.interpolate(0.5154, font_min.info, font_max.info, round=False)
         self.assertEqual(
@@ -125,6 +126,7 @@ class TestInfo(unittest.TestCase):
         interpolated_font, _ = self.objectGenerator("font")
         font_min, _ = self.objectGenerator("font")
         font_max, _ = self.objectGenerator("font")
+        font_min.info.unitsPerEm = 1000
         font_max.info.unitsPerEm = 2000
         interpolated_font.info.interpolate(0.5154, font_min.info, font_max.info, round=True)
         self.assertEqual(

--- a/Lib/fontParts/test/test_info.py
+++ b/Lib/fontParts/test/test_info.py
@@ -92,3 +92,42 @@ class TestInfo(unittest.TestCase):
             info_two,
             a
         )
+
+    # -----
+    # Round
+    # -----
+
+    def test_round_unitsPerEm(self):
+        info = self.getInfo_generic()
+        info.unitsPerEm = 2000.125
+        info.round()
+        self.assertEqual(
+            info.unitsPerEm,
+            2000
+        )
+
+    # -------------
+    # Interpolation
+    # -------------
+
+    def test_interpolate_unitsPerEm_without_rounding(self):
+        interpolated = self.getInfo_generic()
+        info_min = self.getInfo_generic()
+        info_max = self.getInfo_generic()
+        info_max.unitsPerEm = 2000
+        interpolated.interpolate(0.5154, info_min, info_max, round=False)
+        self.assertEqual(
+            info.unitsPerEm,
+            1515.4
+        )
+
+    def test_interpolate_unitsPerEm_with_rounding(self):
+        interpolated = self.getInfo_generic()
+        info_min = self.getInfo_generic()
+        info_max = self.getInfo_generic()
+        info_max.unitsPerEm = 2000
+        interpolated.interpolate(0.5154, info_min, info_max, round=True)
+        self.assertEqual(
+            info.unitsPerEm,
+            1515
+        )

--- a/Lib/fontParts/test/test_kerning.py
+++ b/Lib/fontParts/test/test_kerning.py
@@ -18,6 +18,20 @@ class TestKerning(unittest.TestCase):
         })
         return kerning
 
+    def getKerning_font2(self):
+        font, _ = self.objectGenerator("font")
+        groups = font.groups
+        groups["public.kern1.X"] = ["A", "B", "C"]
+        groups["public.kern2.X"] = ["A", "B", "C"]
+        kerning = font.kerning
+        kerning.update({
+            ("public.kern1.X", "public.kern2.X"): 200,
+            ("B", "public.kern2.X"): 201,
+            ("public.kern1.X", "B"): 202,
+            ("A", "A"): 203,
+        })
+        return kerning
+
     # ---
     # len
     # ---
@@ -258,4 +272,30 @@ class TestKerning(unittest.TestCase):
         self.assertNotEqual(
             kerning_two,
             a
+        )
+
+    # -------------
+    # Interpolation
+    # -------------
+
+    def test_interpolation_without_rounding(self):
+        interpolated = self.getKerning_generic()
+        kerning_min = self.getKerning_generic()
+        kerning_max = self.getKerning_font2()
+        interpolated.interpolate(0.515, kerning_min, kerning_max, round=False)
+
+        self.assertEqual(
+            interpolated[("public.kern1.X", "public.kern2.X")],
+            151.5
+        )
+
+    def test_interpolation_with_rounding(self):
+        interpolated = self.getKerning_generic()
+        kerning_min = self.getKerning_generic()
+        kerning_max = self.getKerning_font2()
+        interpolated.interpolate(0.515, kerning_min, kerning_max, round=True)
+
+        self.assertEqual(
+            interpolated[("public.kern1.X", "public.kern2.X")],
+            152
         )


### PR DESCRIPTION
Would fix #533  

This PR sets fontMath's `setRoundIntegerFunction` to use the `normalize.normalizeVisualRounding` function that the rest of fontParts uses for rounding, instead of the default Python3 `round` in the 4 places where fontMath rounding could take place.

I also added tests to make sure the rounding works as intended.