### PR TITLE
Correct python typo in groups doc — was keys(), should be items()

### DIFF
--- a/documentation/source/objectref/objects/groups.rst
+++ b/documentation/source/objectref/objects/groups.rst
@@ -16,7 +16,7 @@ Groups behave like a Python dictionary. Anything you can do with a dictionary in
 ::
 
     font = CurrentFont()
-    for name, members in font.groups.keys():
+    for name, members in font.groups.items():
         print name
         print members
 


### PR DESCRIPTION
I’ve tripped up a couple of times on the first example at https://fontparts.robotools.dev/en/stable/objectref/objects/groups.html, so here is a small edit that I think makes it accurate.

Was:

```
font = CurrentFont()
for name, members in font.groups.keys():
    print name
    print members
```

Should use `items()` instead:

```
font = CurrentFont()
for name, members in font.groups.items():
    print name
    print members
```