### PR TITLE
Clarify documentation for kerning.find

### DIFF
--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -353,6 +353,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         Returns the value for the kerning pair - even if the pair only exists
         implicitly (one or both sides may be members of a kerning group).
+
         **pair** is a ``tuple`` of two :ref:`type-string`\s, and the returned
         values will either be :ref:`type-int-float` or ``None``
         if no pair was found. ::

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -351,7 +351,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     def find(self, pair, default=None):
         """
-        Returns the value for the kerning pair.
+        Returns the value for the kerning pair - even if the pair only exists
+        implicitly (one or both sides may be members of a kerning group).
         **pair** is a ``tuple`` of two :ref:`type-string`\s, and the returned
         values will either be :ref:`type-int-float` or ``None``
         if no pair was found. ::


### PR DESCRIPTION
The docstring for kerning.get and kerning.find methods was the same, while they perform different operations. I hope this update clarifies the difference a bit.