### PR TITLE
return None when the referenced fileName does not exists in defconFon…

### DIFF
--- a/Lib/fontParts/fontshell/image.py
+++ b/Lib/fontParts/fontshell/image.py
@@ -47,6 +47,8 @@ class RImage(RBaseObject, BaseImage):
         fileName = image.fileName
         if fileName is None:
             return None
+        if fileName not in images:
+            return None
         return images[fileName]
 
     def _set_data(self, value):


### PR DESCRIPTION
…t.images

fixes #566