### PR TITLE
Use explicit imports for _version

### DIFF
--- a/Lib/fontParts/__init__.py
+++ b/Lib/fontParts/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from _version import __version__
+    from ._version import __version__
 except ImportError:
     try:
         from setuptools_scm import get_version


### PR DESCRIPTION
Using implicit relative imports (`from _version import __version__`) does not work in recent python versions (tested with python 3.9.1).
Instead, using explicit path starting with `.` is the recommended way.