### PR TITLE
Documentation: Add a quick start plus a link to the original examples

### DIFF
--- a/documentation/source/gettingstarted/index.rst
+++ b/documentation/source/gettingstarted/index.rst
@@ -5,3 +5,15 @@ Getting Started
 ###############
 
 These need to be ported and updated from RoboFab's documentation.
+
+For a quick start, here's the sample code from the introduction ported to fontparts::
+
+   from fontParts.world import OpenFont
+
+   font = OpenFont("/path/to/my/font.ufo")
+
+   for glyph in font:
+      glyph.leftMargin = glyph.leftMargin + 10
+      glyph.rightMargin = glyph.rightMargin + 10
+
+Find more of the original samples at https://github.com/robotools/robofab/tree/master/Docs/Examples


### PR DESCRIPTION
For new users like me, the lack of a single working example in the introduction makes getting started a daunting task. It took me ages to figure out that "robofab" had to replaced by fontParts with a capital P.

This pull request will hopefully make fontParts just a tiny bit more accessible to newcomers until someone finds the time to flesh out the getting started section (I stashed away a copy of the original document source should I ever get bored).