### PR TITLE
Make doc string more specific for baseComponent.baseGlyph

### DIFF
--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -87,7 +87,7 @@ class BaseComponent(
     # baseGlyph
 
     baseGlyph = dynamicProperty("base_baseGlyph",
-                                "The glyph the component references.")
+                                "The name of the glyph the component references.")
 
     def _get_base_baseGlyph(self):
         value = self._get_baseGlyph()


### PR DESCRIPTION
In the docs (https://fontparts.robotools.dev/en/stable/objectref/objects/component.html#attributes), this definition is slightly misleading. The method returns the glyph name for the referenced glyph – not the glyph object itself.

I think this small change will fix that.