### PR TITLE
Add `validate` kwarg to `RGlyph._loadFromGLIF`

### DIFF
--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -306,12 +306,13 @@ class RGlyph(RBaseObject, BaseGlyph):
     # API
     # ---
 
-    def _loadFromGLIF(self, glifData):
+    def _loadFromGLIF(self, glifData, validate=True):
         try:
             readGlyphFromString(
                 aString=glifData,
                 glyphObject=self.naked(),
-                pointPen=self.getPointPen()
+                pointPen=self.getPointPen(),
+                validate=validate
             )
         except GlifLibError:
             raise FontPartsError("Not valid glif data")


### PR DESCRIPTION
I needed to be able to use this, it's part of the underlying `readGlyphFromString` API.

I also would not oppose letting `_loadFromGLIF` take `**kwargs` which it can pass down to `readGlyphFromString` at maintainer's (@benkiel's?) option, but I do need something like this please. :pleading_face: