### PR TITLE
Add implementation for `glyph.autoContourOrder()`

### DIFF
--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -835,3 +835,33 @@ def reference(obj):
     def wrapper():
         return obj
     return wrapper
+
+
+class FuzzyNumber(object):
+    """
+    A number like object with a threshold.
+    Use it to compare numbers where a threshold is needed.
+    """
+
+    def __init__(self, value, threshold):
+        self.value = value
+        self.threshold = threshold
+
+    def __repr__(self):
+        return "[%f %f]" % (self.value, self.threshold)
+
+    def __lt__(self, other):
+        if hasattr(other, "value"):
+            if abs(self.value - other.value) < self.threshold:
+                return False
+            else:
+                return self.value < other.value
+        return self.value < other
+
+    def __eq__(self, other):
+        if hasattr(other, "value"):
+            return abs(self.value - other.value) < self.threshold
+        return self.value == other
+
+    def __hash__(self):
+        return hash((self.value, self.threshold))

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1514,8 +1514,10 @@ class BaseGlyph(BaseObject,
         Sorting is based on (in this order):
         - the (negative) point count
         - the (negative) segment count
-        - fuzzy x value of the center of the contour
-        - fuzzy y value of the center of the contour
+        - x value of the center of the contour rounded to a threshold
+        - y value of the center of the contour rounded to a threshold
+          (such threshold is calculated as the smallest contour width
+          or height in the glyph divided by two)
         - the (negative) surface of the bounding box of the contour: width * height
         the latter is a safety net for for instances like a very thin 'O' where the
         x centers could be close enough to rely on the y for the sort which could

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -18,6 +18,7 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
+from defcon.tools.fuzzyNumber import FuzzyNumber
 
 
 class BaseGlyph(BaseObject,
@@ -1524,9 +1525,6 @@ class BaseGlyph(BaseObject,
         very well be the same for both contours. We use the _negative_ of the surface
         to ensure that larger contours appear first, which seems more natural.
         """
-        def roundToThreshold(value, threshold):
-            return round(value / float(threshold)) * threshold
-
         tempContourList = []
         contourList = []
         xThreshold = None
@@ -1550,7 +1548,7 @@ class BaseGlyph(BaseObject,
             tempContourList.append((-len(contour.points), -len(contour.segments), xC, yC, -(width * height), contour))
 
         for points, segments, x, y, surface, contour in tempContourList:
-            contourList.append((points, segments, roundToThreshold(x, xThreshold), roundToThreshold(y, yThreshold), surface, contour))
+            contourList.append((points, segments, FuzzyNumber(x, xThreshold), FuzzyNumber(y, yThreshold), surface, contour))
         contourList.sort()
 
         self.clearContours()

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -12,13 +12,13 @@ from fontParts.base.base import (
     InterpolationMixin,
     SelectionMixin,
     dynamicProperty,
-    interpolate
+    interpolate,
+    FuzzyNumber
 )
 from fontParts.base import normalizers
 from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
-from defcon.tools.fuzzyNumber import FuzzyNumber
 
 
 class BaseGlyph(BaseObject,

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -20,21 +20,6 @@ from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
 
 
-class FuzzyNumber(object):
-
-    def __init__(self, value, threshold):
-        self.value = value
-        self.threshold = threshold
-
-    def __lt__(self, other):
-        if abs(self.value - other.value) < self.threshold:
-            return 0
-        else:
-            return (self.value > other.value) - (self.value < other.value)
-
-    __cmp__ = __lt__
-
-
 class BaseGlyph(BaseObject,
                 TransformationMixin,
                 InterpolationMixin,
@@ -1537,6 +1522,9 @@ class BaseGlyph(BaseObject,
         very well be the same for both contours. We use the _negative_ of the surface
         to ensure that larger contours appear first, which seems more natural.
         """
+        def roundToThreshold(value, threshold):
+            return round(value / float(threshold)) * threshold
+
         tempContourList = []
         contourList = []
         xThreshold = None
@@ -1560,7 +1548,7 @@ class BaseGlyph(BaseObject,
             tempContourList.append((-len(contour.points), -len(contour.segments), xC, yC, -(width * height), contour))
 
         for points, segments, x, y, surface, contour in tempContourList:
-            contourList.append((points, segments, FuzzyNumber(x, xThreshold), FuzzyNumber(y, yThreshold), surface, contour))
+            contourList.append((points, segments, roundToThreshold(x, xThreshold), roundToThreshold(y, yThreshold), surface, contour))
         contourList.sort()
 
         self.clearContours()

--- a/Lib/fontParts/test/test_fuzzyNumber.py
+++ b/Lib/fontParts/test/test_fuzzyNumber.py
@@ -1,0 +1,67 @@
+import unittest
+from fontParts.base.base import FuzzyNumber
+
+
+class TestFuzzyNumber(unittest.TestCase):
+
+    def __init__(self, methodName):
+        unittest.TestCase.__init__(self, methodName)
+
+    def test_init(self):
+        fuzzyNumber1 = FuzzyNumber(value=0, threshold=1)
+        fuzzyNumber2 = FuzzyNumber(2, 3)
+        self.assertEqual([fuzzyNumber1.value, fuzzyNumber1.threshold],
+                         [0, 1])
+        self.assertEqual([fuzzyNumber2.value, fuzzyNumber2.threshold],
+                         [2, 3])
+
+    def test_repr(self):
+        fuzzyNumber = FuzzyNumber(0, 1)
+        self.assertEqual(repr(fuzzyNumber), "[0.000000 1.000000]")
+
+    def test_comparison(self):
+        fuzzyNumber1 = FuzzyNumber(value=0, threshold=1)
+        self.assertEqual(fuzzyNumber1, 0)
+        self.assertTrue(fuzzyNumber1 < 1)
+        self.assertFalse(fuzzyNumber1 < -0.000001)
+        self.assertFalse(fuzzyNumber1 < 0)
+
+        fuzzyNumber2 = FuzzyNumber(value=0.999999, threshold=1)
+        self.assertEqual(
+            repr(sorted([fuzzyNumber1, fuzzyNumber2])),
+            "[[0.000000 1.000000], [0.999999 1.000000]]"
+        )
+        self.assertFalse(fuzzyNumber1 < fuzzyNumber2)
+
+        fuzzyNumber2 = FuzzyNumber(value=1, threshold=1)
+        self.assertEqual(
+            repr(sorted([fuzzyNumber1, fuzzyNumber2])),
+            "[[0.000000 1.000000], [1.000000 1.000000]]"
+        )
+        self.assertTrue(fuzzyNumber1 < fuzzyNumber2)
+
+        fuzzyNumber2 = FuzzyNumber(value=-0.999999, threshold=1)
+        self.assertEqual(
+            repr(sorted([fuzzyNumber1, fuzzyNumber2])),
+            "[[0.000000 1.000000], [-0.999999 1.000000]]"
+        )
+        self.assertFalse(fuzzyNumber1 > fuzzyNumber2)
+
+        fuzzyNumber2 = FuzzyNumber(value=-1, threshold=1)
+        self.assertEqual(
+            repr(sorted([fuzzyNumber1, fuzzyNumber2])),
+            "[[-1.000000 1.000000], [0.000000 1.000000]]"
+        )
+        self.assertTrue(fuzzyNumber1 > fuzzyNumber2)
+
+        # equal
+        self.assertEqual(fuzzyNumber1, fuzzyNumber1)
+        self.assertNotEqual(fuzzyNumber1, fuzzyNumber2)
+
+        # complex sorting
+        fuzzyNumber2 = FuzzyNumber(value=0.999999, threshold=1)
+        self.assertEqual(
+            repr(sorted([(fuzzyNumber1, 20), (fuzzyNumber2, 10)])),
+            "[([0.999999 1.000000], 10), ([0.000000 1.000000], 20)]"
+        )
+

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1,7 +1,6 @@
 import unittest
 import collections
 from fontParts.base import FontPartsError
-from fontTools.pens.areaPen import AreaPen
 from .test_image import testImageData
 
 

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -30,6 +30,14 @@ class TestGlyph(unittest.TestCase):
         glyph.appendGuideline((3, 4), 90, "Test Guideline 2")
         return glyph
 
+    def getGlyph_empty(self):
+        glyph, _ = self.objectGenerator("glyph")
+        glyph.name = "Test Glyph 2"
+        glyph.unicode = int(ord("X"))
+        glyph.width = 0
+        glyph.height = 0
+        return glyph
+
     def get_generic_object(self, obj_name):
         fp_object, _ = self.objectGenerator(obj_name)
         return fp_object
@@ -444,7 +452,7 @@ class TestGlyph(unittest.TestCase):
         self.assertEqual(len(glyph), 0)
 
     def test_autoContourOrder_points(self):
-        glyph = self.getGlyph_generic()
+        glyph = self.getGlyph_empty()
         pen = glyph.getPen()
         pen.moveTo((287, 212))
         pen.lineTo((217, 108))
@@ -473,7 +481,7 @@ class TestGlyph(unittest.TestCase):
         self.assertEqual([len(c.points) for c in glyph.contours], [7, 5, 3])
 
     def test_autoContourOrder_segments(self):
-        glyph = self.getGlyph_generic()
+        glyph = self.getGlyph_empty()
 
         pen = glyph.getPen()
         pen.moveTo((116, 202))
@@ -490,56 +498,92 @@ class TestGlyph(unittest.TestCase):
         glyph.autoContourOrder()
         self.assertEqual([len(c.segments) for c in glyph.contours], [4, 2])
 
-    def test_autoContourOrder_center(self):
-        glyph = self.getGlyph_generic()
+    def test_autoContourOrder_fuzzycenter(self):
+        glyph = self.getGlyph_empty()
 
+        # the contours are overlapping too much
+        # the different position of their center points
+        # should not matter
         pen = glyph.getPen()
-        pen.moveTo((218, 129))
-        pen.curveTo((279, 129), (329, 179), (329, 240))
-        pen.curveTo((329, 301), (279, 351), (218, 351))
-        pen.curveTo((157, 351), (107, 301), (107, 240))
-        pen.curveTo((107, 179), (157, 129), (218, 129))
+        pen.moveTo((313, 44))
+        pen.curveTo((471, 44), (600, 174), (600, 332))
+        pen.curveTo((600, 490), (471, 619), (313, 619))
+        pen.curveTo((155, 619), (26, 490), (26, 332))
+        pen.curveTo((26, 174), (155, 44), (313, 44))
         pen.closePath()
 
         pen = glyph.getPen()
-        pen.moveTo((188, 99))
-        pen.curveTo((249, 99), (299, 149), (299, 210))
-        pen.curveTo((299, 271), (249, 321), (188, 321))
-        pen.curveTo((127, 321), (77, 271), (77, 210))
-        pen.curveTo((77, 149), (127, 99), (188, 99))
-        pen.closePath()
-
-        glyph.autoContourOrder()
-        self.assertTrue(glyph.contours[0].bounds < glyph.contours[1].bounds)
-
-    def test_autoContourOrder_surface(self):
-        glyph = self.getGlyph_generic()
-
-        pen = glyph.getPen()
-        pen.moveTo((192, 30))
-        pen.curveTo((282, 30), (355, 103), (355, 193))
-        pen.curveTo((355, 282), (282, 356), (192, 356))
-        pen.curveTo((102, 356), (29, 282), (29, 193))
-        pen.curveTo((29, 103), (102, 30), (192, 30))
-        pen.closePath()
-
-        pen = glyph.getPen()
-        pen.moveTo((192, 30))
-        pen.curveTo((355, 30), (355, 30), (355, 193))
-        pen.curveTo((355, 356), (355, 356), (192, 356))
-        pen.curveTo((29, 356), (29, 356), (29, 193))
-        pen.curveTo((29, 30), (29, 30), (192, 30))
+        pen.moveTo((288, 122))
+        pen.curveTo((383, 122), (461, 200), (461, 295))
+        pen.curveTo((461, 390), (383, 468), (288, 468))
+        pen.curveTo((192, 468), (114, 390), (114, 295))
+        pen.curveTo((114, 200), (192, 122), (288, 122))
         pen.closePath()
 
         glyph.autoContourOrder()
 
-        firstAreaPen = AreaPen()
-        glyph.contours[0].draw(firstAreaPen)
+        self.assertTrue(
+            glyph.contours[0].points[0].x == 313
+            and glyph.contours[1].points[0].x == 288
+        )
 
-        secondAreaPen = AreaPen()
-        glyph.contours[1].draw(firstAreaPen)
+    def test_autoContourOrder_distantCenter(self):
+        glyph = self.getGlyph_empty()
 
-        self.assertTrue(firstAreaPen.value > secondAreaPen.value)
+        # both outlines have same structure
+        # but their center points are far away
+        # so, the center points should inform
+        # the sorting
+        # from left to right first, then bottom to top
+        pen = glyph.getPen()
+        pen.moveTo((313, 44))
+        pen.curveTo((471, 44), (600, 174), (600, 332))
+        pen.curveTo((600, 490), (471, 619), (313, 619))
+        pen.curveTo((155, 619), (26, 490), (26, 332))
+        pen.curveTo((26, 174), (155, 44), (313, 44))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((-142, -118))
+        pen.curveTo((-47, -118), (31, -40), (31, 55))
+        pen.curveTo((31, 150), (-47, 228), (-142, 228))
+        pen.curveTo((-238, 228), (-316, 150), (-316, 55))
+        pen.curveTo((-316, -40), (-238, -118), (-142, -118))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+        self.assertTrue(
+            glyph.contours[0].points[0].x == -142
+            and glyph.contours[1].points[0].x == 313
+        )
+
+    def test_autoContourOrder_bboxsurface(self):
+        glyph = self.getGlyph_empty()
+
+        # both outlines share the same center
+        # so, the surface of the bounding box should inform
+        # the sorting, from larger to smaller
+        pen = glyph.getPen()
+        pen.moveTo((100, 50))
+        pen.curveTo((128, 50), (150, 72), (150, 100))
+        pen.curveTo((150, 128), (128, 150), (100, 150))
+        pen.curveTo((72, 150), (50, 128), (50, 100))
+        pen.curveTo((50, 72), (72, 50), (100, 50))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((100, 0))
+        pen.curveTo((155, 0), (200, 45), (200, 100))
+        pen.curveTo((200, 155), (155, 200), (100, 200))
+        pen.curveTo((45, 200), (0, 155), (0, 100))
+        pen.curveTo((0, 45), (45, 0), (100, 0))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+        self.assertTrue(
+            glyph.contours[0].points[0].y == 0
+            and glyph.contours[1].points[0].y == 50
+        )
 
     # ----------
     # Components

--- a/Lib/fontParts/test/test_glyph.py
+++ b/Lib/fontParts/test/test_glyph.py
@@ -1,6 +1,7 @@
 import unittest
 import collections
 from fontParts.base import FontPartsError
+from fontTools.pens.areaPen import AreaPen
 from .test_image import testImageData
 
 
@@ -441,6 +442,104 @@ class TestGlyph(unittest.TestCase):
         self.assertEqual(len(glyph), 2)
         glyph.clearContours()
         self.assertEqual(len(glyph), 0)
+
+    def test_autoContourOrder_points(self):
+        glyph = self.getGlyph_generic()
+        pen = glyph.getPen()
+        pen.moveTo((287, 212))
+        pen.lineTo((217, 108))
+        pen.lineTo((407, 109))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((73, 184))
+        pen.lineTo((39, 112))
+        pen.lineTo((147, 61))
+        pen.lineTo((140, 137))
+        pen.lineTo((110, 176))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((60, 351))
+        pen.lineTo((149, 421))
+        pen.lineTo((225, 398))
+        pen.lineTo((237, 290))
+        pen.lineTo((183, 239))
+        pen.lineTo((129, 245))
+        pen.lineTo((70, 285))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+        self.assertEqual([len(c.points) for c in glyph.contours], [7, 5, 3])
+
+    def test_autoContourOrder_segments(self):
+        glyph = self.getGlyph_generic()
+
+        pen = glyph.getPen()
+        pen.moveTo((116, 202))
+        pen.curveTo((116, 308), (156, 348), (245, 348))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((261, 212))
+        pen.lineTo((335, 212))
+        pen.lineTo((335, 301))
+        pen.lineTo((261, 301))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+        self.assertEqual([len(c.segments) for c in glyph.contours], [4, 2])
+
+    def test_autoContourOrder_center(self):
+        glyph = self.getGlyph_generic()
+
+        pen = glyph.getPen()
+        pen.moveTo((218, 129))
+        pen.curveTo((279, 129), (329, 179), (329, 240))
+        pen.curveTo((329, 301), (279, 351), (218, 351))
+        pen.curveTo((157, 351), (107, 301), (107, 240))
+        pen.curveTo((107, 179), (157, 129), (218, 129))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((188, 99))
+        pen.curveTo((249, 99), (299, 149), (299, 210))
+        pen.curveTo((299, 271), (249, 321), (188, 321))
+        pen.curveTo((127, 321), (77, 271), (77, 210))
+        pen.curveTo((77, 149), (127, 99), (188, 99))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+        self.assertTrue(glyph.contours[0].bounds < glyph.contours[1].bounds)
+
+    def test_autoContourOrder_surface(self):
+        glyph = self.getGlyph_generic()
+
+        pen = glyph.getPen()
+        pen.moveTo((192, 30))
+        pen.curveTo((282, 30), (355, 103), (355, 193))
+        pen.curveTo((355, 282), (282, 356), (192, 356))
+        pen.curveTo((102, 356), (29, 282), (29, 193))
+        pen.curveTo((29, 103), (102, 30), (192, 30))
+        pen.closePath()
+
+        pen = glyph.getPen()
+        pen.moveTo((192, 30))
+        pen.curveTo((355, 30), (355, 30), (355, 193))
+        pen.curveTo((355, 356), (355, 356), (192, 356))
+        pen.curveTo((29, 356), (29, 356), (29, 193))
+        pen.curveTo((29, 30), (29, 30), (192, 30))
+        pen.closePath()
+
+        glyph.autoContourOrder()
+
+        firstAreaPen = AreaPen()
+        glyph.contours[0].draw(firstAreaPen)
+
+        secondAreaPen = AreaPen()
+        glyph.contours[1].draw(firstAreaPen)
+
+        self.assertTrue(firstAreaPen.value > secondAreaPen.value)
 
     # ----------
     # Components

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,7 @@
+0.10.4 (released 2022-03-17)
+---------------------------
+- Fixes issue with setting glyph name when copying. Issue #633. (thanks @typemytype!)
+
 0.10.3 (released 2022-02-24)
 ---------------------------
 - Fixes issue with `defaultLayer` and copying a `font`. Issue #630. (thanks @typemytype!)


### PR DESCRIPTION
as #645 

This morning @typemytype realized that sorting `FuzzyNumber`s along with other types does not work as expected. So the old `roboFab` implementation needed some adjustments. I mark this as WIP as it might need some extra testing!