### PR TITLE
update to print() + switch indentation to spaces

### DIFF
--- a/documentation/source/objectref/objects/anchor.rst
+++ b/documentation/source/objectref/objects/anchor.rst
@@ -13,9 +13,9 @@ Anchors are single points in a glyph which are not part of a contour. They can b
 
 ::
 
-	glyph = CurrentGlyph()
-	for anchor in glyph.anchors:
-		print anchor
+    glyph = CurrentGlyph()
+    for anchor in glyph.anchors:
+        print(anchor)
 
 ********
 Overview

--- a/documentation/source/objectref/objects/features.rst
+++ b/documentation/source/objectref/objects/features.rst
@@ -15,8 +15,8 @@ Features is text in the `Adobe Font Development Kit <http://www.adobe.com/devnet
 
 ::
 
-	font = CurrentFont()
-	print font.features
+    font = CurrentFont()
+    print(font.features)
 
 ********
 Overview

--- a/documentation/source/objectref/objects/groups.rst
+++ b/documentation/source/objectref/objects/groups.rst
@@ -17,8 +17,8 @@ Groups behave like a Python dictionary. Anything you can do with a dictionary in
 
     font = CurrentFont()
     for name, members in font.groups.items():
-        print name
-        print members
+        print(name)
+        print(members)
 
 It is important to understand that any changes to the returned group contents will not be reflected in the groups object. This means that the following will not update the font's groups:
 

--- a/documentation/source/objectref/objects/guideline.rst
+++ b/documentation/source/objectref/objects/guideline.rst
@@ -13,9 +13,9 @@ Guidelines are reference lines in a glyph that are not part of a contour or the 
 
 ::
 
-	glyph = CurrentGlyph()
-	for guideline in glyph.guidelines:
-		print guideline
+    glyph = CurrentGlyph()
+    for guideline in glyph.guidelines:
+        print(guideline)
 
 ********
 Overview

--- a/documentation/source/objectref/objects/point.rst
+++ b/documentation/source/objectref/objects/point.rst
@@ -13,10 +13,10 @@ Description
 
 ::
 
-	glyph = CurrentGlyph()
-	for contour in glyph:
-		for point in contour.points:
-			print point
+    glyph = CurrentGlyph()
+    for contour in glyph:
+        for point in contour.points:
+            print(point)
 
 ********
 Overview


### PR DESCRIPTION
tabs seem to mess up layout on the web (the groups web page is the only one using spaces and it looks fine)

screenshots for reference:

+ anchors (using tabs)
<img width="889" alt="Screenshot 2022-05-18 at 17 57 21" src="https://user-images.githubusercontent.com/2218712/169089845-4b699054-bebc-402e-bebf-4d56c5afa477.png">


+ groups (using spaces)
<img width="889" alt="Screenshot 2022-05-18 at 18 06 09" src="https://user-images.githubusercontent.com/2218712/169089879-5b4cf141-6ce4-43ee-938c-2a3cc6adddce.png">

