### PR TITLE
Change how anchor name value is gotten 

### DIFF
--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1694,7 +1694,7 @@ class BaseGlyph(BaseObject,
         mathGlyph.drawPoints(pen, filterRedundantPoints=filterRedundantPoints)
         for anchor in mathGlyph.anchors:
             a = copied.appendAnchor(
-                name=anchor["name"],
+                name=anchor.get("name"),
                 position=(anchor["x"], anchor["y"]),
                 color=anchor["color"]
             )


### PR DESCRIPTION
This should account for getting a value that doesn't exist in a math glyph, addressing #678 