### PR TITLE
Adding link to the UFO specification in the Info docs

### DIFF
--- a/documentation/source/objectref/objects/info.rst
+++ b/documentation/source/objectref/objects/info.rst
@@ -13,6 +13,8 @@ The :class:`Info <BaseInfo>` object contains all names, numbers, URLs, dimension
 
 :class:`Info <BaseInfo>` validates any value set for a `Info <BaseInfo>` item, but does not check if the data is sane (i.e., you can set valid but incorrect data).
 
+For a list of info attributes, refer to the `UFO fontinfo.plist Specification <https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#specification>`_.
+
 ********
 Overview
 ********


### PR DESCRIPTION
Fixes #689 

An attempt to add a link to the UFO specification in the description section of the Info object documentation... my first time messing with the docs, not sure if I did it right!