### PR TITLE
`point.py` annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/*
 dist/*
 .eggs/
 .vscode
+.venv
 
 documentation/build/*
 documentation/.sass-cache/*

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -1,0 +1,39 @@
+# pylint: disable=C0103, C0114
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple, TypeVar, Union
+
+from fontTools.pens.basePen import AbstractPen
+from fontTools.pens.pointPen import AbstractPointPen
+
+# ------------
+# Type Aliases
+# ------------
+
+# Builtins
+
+T = TypeVar('T')
+CollectionType = Union[List[T], Tuple[T, ...]]
+IntFloatType = Union[int, float]
+
+# FontTools
+
+PenType = AbstractPen
+PointPenType = AbstractPointPen
+
+# FontParts
+
+BoundsType = Tuple[IntFloatType, IntFloatType, IntFloatType, IntFloatType]
+CharacterMappingType = Dict[int, Tuple[str, ...]]
+ColorType = Tuple[IntFloatType, IntFloatType, IntFloatType, IntFloatType]
+CoordinateType = Tuple[IntFloatType, IntFloatType]
+FactorType = Union[IntFloatType, Tuple[float, float]]
+KerningKeyType = Tuple[str, str]
+KerningDictType = Dict[KerningKeyType, IntFloatType]
+ReverseComponentMappingType = Dict[str, Tuple[str, ...]]
+ScaleType = Tuple[IntFloatType, IntFloatType]
+TransformationMatrixType = Tuple[
+    IntFloatType, IntFloatType, IntFloatType,
+    IntFloatType, IntFloatType, IntFloatType
+]

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -1,9 +1,10 @@
 import math
 from copy import deepcopy
-from fontTools.misc import transform
-from fontParts.base.errors import FontPartsError
-from fontParts.base import normalizers
+from typing import List
 
+from fontParts.base import normalizers
+from fontParts.base.errors import FontPartsError
+from fontTools.misc import transform
 
 # -------
 # Helpers
@@ -145,7 +146,7 @@ class BaseObject:
         return s
 
     @classmethod
-    def _reprContents(cls):
+    def _reprContents(cls) -> List[str]:
         """
         Subclasses may override this method to
         provide a list of strings for inclusion
@@ -191,7 +192,7 @@ class BaseObject:
     # ----
 
     copyClass = None
-    copyAttributes = ()
+    copyAttributes: tuple[str, ...] = ()
 
     def copy(self):
         """

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -9,7 +9,7 @@ from fontParts.base import normalizers
 # Helpers
 # -------
 
-class dynamicProperty(object):
+class dynamicProperty:
 
     """
     This implements functionality that is very similar
@@ -17,7 +17,7 @@ class dynamicProperty(object):
     it much easier for subclassing. Here is an example
     of why this is needed:
 
-        class BaseObject(object):
+        class BaseObject:
 
             _foo = 1
 
@@ -51,7 +51,7 @@ class dynamicProperty(object):
 
     Using dynamicProperty solves this.
 
-        class BaseObject(object):
+        class BaseObject:
 
             _foo = 1
 
@@ -111,7 +111,7 @@ def interpolate(a, b, v):
 # Base Objects
 # ------------
 
-class BaseObject(object):
+class BaseObject:
 
     # --------------
     # Initialization
@@ -445,7 +445,7 @@ class BaseDict(BaseObject):
             del self[key]
 
 
-class TransformationMixin(object):
+class TransformationMixin:
 
     # ---------------
     # Transformations
@@ -638,7 +638,7 @@ class TransformationMixin(object):
         self.transformBy(tuple(t), origin=origin, **kwargs)
 
 
-class InterpolationMixin(object):
+class InterpolationMixin:
 
     # -------------
     # Compatibility
@@ -666,7 +666,7 @@ class InterpolationMixin(object):
         self.raiseNotImplementedError()
 
 
-class SelectionMixin(object):
+class SelectionMixin:
 
     # -------------
     # Selected Flag
@@ -732,7 +732,7 @@ class SelectionMixin(object):
             obj.selected = obj in selected
 
 
-class PointPositionMixin(object):
+class PointPositionMixin:
 
     """
     This adds a ``position`` attribute as a dyanmicProperty,
@@ -768,7 +768,7 @@ class PointPositionMixin(object):
         self.moveBy((dX, dY))
 
 
-class IdentifierMixin(object):
+class IdentifierMixin:
 
     # identifier
 
@@ -837,7 +837,7 @@ def reference(obj):
     return wrapper
 
 
-class FuzzyNumber(object):
+class FuzzyNumber:
     """
     A number like object with a threshold.
     Use it to compare numbers where a threshold is needed.

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -5,7 +5,7 @@ from fontParts.base.base import dynamicProperty
 # ----
 
 
-class BaseCompatibilityReporter(object):
+class BaseCompatibilityReporter:
 
     objectName = "Base"
 

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -12,14 +12,14 @@ class RemovedError(Exception):
 # = base =
 # ========
 
-class RemovedBase(object):
+class RemovedBase:
 
     def setParent(self, parent):
         objName = self.__class__.__name__.replace("Removed", "")
         raise RemovedError("'%s.setParent()'" % objName)
 
 
-class DeprecatedBase(object):
+class DeprecatedBase:
 
     def update(self):
         objName = self.__class__.__name__.replace("Deprecated", "")
@@ -38,7 +38,7 @@ class DeprecatedBase(object):
 # = transformation =
 # ==================
 
-class DeprecatedTransformation(object):
+class DeprecatedTransformation:
 
     def move(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
@@ -421,7 +421,7 @@ class RemovedLib(RemovedBase):
     pass
 
 
-class DeprecatedLib(object):
+class DeprecatedLib:
 
     def getParent(self):
         warnings.warn("'Lib.getParent()': use 'Lib.glyph' or 'Lib.font'",
@@ -446,7 +446,7 @@ class RemovedGroups(RemovedBase):
     pass
 
 
-class DeprecatedGroups(object):
+class DeprecatedGroups:
 
     def getParent(self):
         warnings.warn("'Groups.getParent()': use 'Groups.font'",
@@ -463,7 +463,7 @@ class DeprecatedGroups(object):
 # = Kerning =
 # ===========
 
-class RemovedKerning(object):
+class RemovedKerning:
 
     @staticmethod
     def setParent(parent):
@@ -525,7 +525,7 @@ class RemovedKerning(object):
         raise RemovedError("Kerning.explodeClasses()")
 
 
-class DeprecatedKerning(object):
+class DeprecatedKerning:
 
     def setChanged(self):
         warnings.warn("'Kerning.setChanged': use Kerning.changed()",

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -1,15 +1,18 @@
-from fontTools.misc import transform
-from fontParts.base.base import (
-    BaseObject,
-    TransformationMixin,
-    PointPositionMixin,
-    SelectionMixin,
-    IdentifierMixin,
-    dynamicProperty,
-    reference
-)
+from numbers import Number
+from typing import List, Optional
+
 from fontParts.base import normalizers
+from fontParts.base.annotations import TransformationMatrixType
+from fontParts.base.base import (BaseObject, IdentifierMixin,
+                                 PointPositionMixin, SelectionMixin,
+                                 TransformationMixin, dynamicProperty,
+                                 reference)
+from fontParts.base.contour import BaseContour
 from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
+from fontParts.base.font import BaseFont
+from fontParts.base.glyph import BaseGlyph
+from fontParts.base.layer import BaseLayer
+from fontTools.misc import transform
 
 
 class BasePoint(
@@ -40,7 +43,7 @@ class BasePoint(
         "name"
     )
 
-    def _reprContents(self):
+    def _reprContents(self) -> List[str]:
         contents = [
             "%s" % self.type,
             ("({x}, {y})".format(x=self.x, y=self.y)),
@@ -57,17 +60,17 @@ class BasePoint(
 
     # Contour
 
-    _contour = None
+    _contour: Optional[BaseContour] = None
 
-    contour = dynamicProperty("contour",
+    contour: dynamicProperty = dynamicProperty("contour",
                               "The point's parent :class:`BaseContour`.")
 
-    def _get_contour(self):
+    def _get_contour(self) -> Optional[BaseContour]:
         if self._contour is None:
             return None
         return self._contour()
 
-    def _set_contour(self, contour):
+    def _set_contour(self, contour: BaseContour):
         if self._contour is not None:
             raise AssertionError("contour for point already set")
         if contour is not None:
@@ -76,27 +79,27 @@ class BasePoint(
 
     # Glyph
 
-    glyph = dynamicProperty("glyph", "The point's parent :class:`BaseGlyph`.")
+    glyph: dynamicProperty = dynamicProperty("glyph", "The point's parent :class:`BaseGlyph`.")
 
-    def _get_glyph(self):
+    def _get_glyph(self) -> Optional[BaseGlyph]:
         if self._contour is None:
             return None
         return self.contour.glyph
 
     # Layer
 
-    layer = dynamicProperty("layer", "The point's parent :class:`BaseLayer`.")
+    layer: dynamicProperty = dynamicProperty("layer", "The point's parent :class:`BaseLayer`.")
 
-    def _get_layer(self):
+    def _get_layer(self) -> Optional[BaseLayer]:
         if self._contour is None:
             return None
         return self.glyph.layer
 
     # Font
 
-    font = dynamicProperty("font", "The point's parent :class:`BaseFont`.")
+    font: dynamicProperty = dynamicProperty("font", "The point's parent :class:`BaseFont`.")
 
-    def _get_font(self):
+    def _get_font(self) -> Optional[BaseFont]:
         if self._contour is None:
             return None
         return self.glyph.font
@@ -107,7 +110,7 @@ class BasePoint(
 
     # type
 
-    type = dynamicProperty(
+    type: dynamicProperty = dynamicProperty(
         "base_type",
         """
         The point type defined with a :ref:`type-string`.
@@ -126,12 +129,12 @@ class BasePoint(
         +----------+---------------------------------+
         """)
 
-    def _get_base_type(self):
+    def _get_base_type(self) -> str:
         value = self._get_type()
         value = normalizers.normalizePointType(value)
         return value
 
-    def _set_base_type(self, value):
+    def _set_base_type(self, value: str):
         value = normalizers.normalizePointType(value)
         self._set_type(value)
 
@@ -146,7 +149,7 @@ class BasePoint(
         """
         self.raiseNotImplementedError()
 
-    def _set_type(self, value):
+    def _set_type(self, value: str):
         """
         This is the environment implementation
         of :attr:`BasePoint.type`. **value**
@@ -160,7 +163,7 @@ class BasePoint(
 
     # smooth
 
-    smooth = dynamicProperty(
+    smooth: dynamicProperty = dynamicProperty( # type: ignore
         "base_smooth",
         """
         A ``bool`` indicating if the point is smooth or not. ::
@@ -172,12 +175,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_smooth(self):
+    def _get_base_smooth(self) -> bool:
         value = self._get_smooth()
         value = normalizers.normalizeBoolean(value)
         return value
 
-    def _set_base_smooth(self, value):
+    def _set_base_smooth(self, value: bool):
         value = normalizers.normalizeBoolean(value)
         self._set_smooth(value)
 
@@ -205,7 +208,7 @@ class BasePoint(
 
     # x
 
-    x = dynamicProperty(
+    x: dynamicProperty = dynamicProperty(
         "base_x",
         """
         The x coordinate of the point.
@@ -217,12 +220,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_x(self):
+    def _get_base_x(self) -> Number:
         value = self._get_x()
         value = normalizers.normalizeX(value)
         return value
 
-    def _set_base_x(self, value):
+    def _set_base_x(self, value: Number):
         value = normalizers.normalizeX(value)
         self._set_x(value)
 
@@ -248,7 +251,7 @@ class BasePoint(
 
     # y
 
-    y = dynamicProperty(
+    y: dynamicProperty = dynamicProperty(
         "base_y",
         """
         The y coordinate of the point.
@@ -260,12 +263,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_y(self):
+    def _get_base_y(self) -> Number:
         value = self._get_y()
         value = normalizers.normalizeY(value)
         return value
 
-    def _set_base_y(self, value):
+    def _set_base_y(self, value: Number):
         value = normalizers.normalizeY(value)
         self._set_y(value)
 
@@ -295,7 +298,7 @@ class BasePoint(
 
     # index
 
-    index = dynamicProperty(
+    index: dynamicProperty = dynamicProperty(
         "base_index",
         """
         The index of the point within the ordered
@@ -307,12 +310,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_index(self):
+    def _get_base_index(self) -> Optional[int]:
         value = self._get_index()
         value = normalizers.normalizeIndex(value)
         return value
 
-    def _get_index(self):
+    def _get_index(self) -> Optional[int]:
         """
         Get the point's index.
         This must return an ``int``.
@@ -326,7 +329,7 @@ class BasePoint(
 
     # name
 
-    name = dynamicProperty(
+    name: dynamicProperty = dynamicProperty(
         "base_name",
         """
         The name of the point. This will be a
@@ -338,13 +341,13 @@ class BasePoint(
         """
     )
 
-    def _get_base_name(self):
+    def _get_base_name(self) -> Optional[str]:
         value = self._get_name()
         if value is not None:
             value = normalizers.normalizePointName(value)
         return value
 
-    def _set_base_name(self, value):
+    def _set_base_name(self, value: str):
         if value is not None:
             value = normalizers.normalizePointName(value)
         self._set_name(value)
@@ -377,7 +380,7 @@ class BasePoint(
     # Transformation
     # --------------
 
-    def _transformBy(self, matrix, **kwargs):
+    def _transformBy(self, matrix: TransformationMatrixType, **kwargs):
         """
         This is the environment implementation of
         :meth:`BasePoint.transformBy`.

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -4,10 +4,15 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from fontParts.base import normalizers
 from fontParts.base.annotations import TransformationMatrixType
-from fontParts.base.base import (BaseObject, IdentifierMixin,
-                                 PointPositionMixin, SelectionMixin,
-                                 TransformationMixin, dynamicProperty,
-                                 reference)
+from fontParts.base.base import (
+    BaseObject,
+    IdentifierMixin,
+    PointPositionMixin,
+    SelectionMixin,
+    TransformationMixin,
+    dynamicProperty,
+    reference
+)
 from fontTools.misc import transform
 
 if TYPE_CHECKING:

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -1,5 +1,6 @@
-from numbers import Number
-from typing import List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from fontParts.base import normalizers
 from fontParts.base.annotations import TransformationMatrixType
@@ -7,12 +8,15 @@ from fontParts.base.base import (BaseObject, IdentifierMixin,
                                  PointPositionMixin, SelectionMixin,
                                  TransformationMixin, dynamicProperty,
                                  reference)
-from fontParts.base.contour import BaseContour
-from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
-from fontParts.base.font import BaseFont
-from fontParts.base.glyph import BaseGlyph
-from fontParts.base.layer import BaseLayer
 from fontTools.misc import transform
+
+if TYPE_CHECKING:
+    from fontParts.base.annotations import IntFloatType
+    from fontParts.base.contour import BaseContour
+    from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
+    from fontParts.base.font import BaseFont
+    from fontParts.base.glyph import BaseGlyph
+    from fontParts.base.layer import BaseLayer
 
 
 class BasePoint(
@@ -70,7 +74,7 @@ class BasePoint(
             return None
         return self._contour()
 
-    def _set_contour(self, contour: BaseContour):
+    def _set_contour(self, contour: BaseContour) -> None:
         if self._contour is not None:
             raise AssertionError("contour for point already set")
         if contour is not None:
@@ -134,7 +138,7 @@ class BasePoint(
         value = normalizers.normalizePointType(value)
         return value
 
-    def _set_base_type(self, value: str):
+    def _set_base_type(self, value: str) -> None:
         value = normalizers.normalizePointType(value)
         self._set_type(value)
 
@@ -163,7 +167,7 @@ class BasePoint(
 
     # smooth
 
-    smooth: dynamicProperty = dynamicProperty( # type: ignore
+    smooth: dynamicProperty = dynamicProperty(
         "base_smooth",
         """
         A ``bool`` indicating if the point is smooth or not. ::
@@ -180,7 +184,7 @@ class BasePoint(
         value = normalizers.normalizeBoolean(value)
         return value
 
-    def _set_base_smooth(self, value: bool):
+    def _set_base_smooth(self, value: bool) -> None:
         value = normalizers.normalizeBoolean(value)
         self._set_smooth(value)
 
@@ -220,12 +224,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_x(self) -> Number:
+    def _get_base_x(self) -> IntFloatType:
         value = self._get_x()
         value = normalizers.normalizeX(value)
         return value
 
-    def _set_base_x(self, value: Number):
+    def _set_base_x(self, value: IntFloatType) -> None:
         value = normalizers.normalizeX(value)
         self._set_x(value)
 
@@ -263,12 +267,12 @@ class BasePoint(
         """
     )
 
-    def _get_base_y(self) -> Number:
+    def _get_base_y(self) -> IntFloatType:
         value = self._get_y()
         value = normalizers.normalizeY(value)
         return value
 
-    def _set_base_y(self, value: Number):
+    def _set_base_y(self, value: IntFloatType) -> None:
         value = normalizers.normalizeY(value)
         self._set_y(value)
 
@@ -347,7 +351,7 @@ class BasePoint(
             value = normalizers.normalizePointName(value)
         return value
 
-    def _set_base_name(self, value: str):
+    def _set_base_name(self, value: str) -> None:
         if value is not None:
             value = normalizers.normalizePointName(value)
         self._set_name(value)
@@ -380,7 +384,7 @@ class BasePoint(
     # Transformation
     # --------------
 
-    def _transformBy(self, matrix: TransformationMatrixType, **kwargs):
+    def _transformBy(self, matrix: TransformationMatrixType, **kwargs: Any) -> None:
         """
         This is the environment implementation of
         :meth:`BasePoint.transformBy`.
@@ -400,7 +404,7 @@ class BasePoint(
     # Normalization
     # -------------
 
-    def round(self):
+    def round(self) -> None:
         """
         Round the point's coordinate.
 
@@ -413,7 +417,7 @@ class BasePoint(
         """
         self._round()
 
-    def _round(self, **kwargs):
+    def _round(self, **kwargs: Any):
         """
         This is the environment implementation of
         :meth:`BasePoint.round`.

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -35,7 +35,7 @@ class BasePoint(
         >>> point = RPoint()
     """
 
-    copyAttributes = (
+    copyAttributes: Tuple[str, str, str, str, str] = (
         "type",
         "smooth",
         "x",

--- a/Lib/fontParts/fontshell/base.py
+++ b/Lib/fontParts/fontshell/base.py
@@ -1,4 +1,4 @@
-class RBaseObject(object):
+class RBaseObject:
 
     wrapClass = None
 

--- a/Lib/fontParts/world.py
+++ b/Lib/fontParts/world.py
@@ -612,7 +612,7 @@ def _sortValue_isMonospace(font):
 # Dispatcher
 # ----------
 
-class _EnvironmentDispatcher(object):
+class _EnvironmentDispatcher:
 
     def __init__(self, registryItems):
         self._registry = {item: None for item in registryItems}


### PR DESCRIPTION
Hey @benkiel,

As agreed in PR #739, I will create a separate PR for each module. I'm trying to follow the same patterns that @knutnergaard used in his PR. If I understand the work done so far correctly, I only need to annotate the module in `fontParts.base`, right?

@knutnergaard, could you review my proposal to ensure it follows the same steps as yours?

Since the work so far has focused on `font.py` and `glyph.py`, I plan to start with the smaller objects and work my way up.

cc: @typemytype