### PR TITLE
Remove unecessary list comprehensions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ htmlcov
 
 # scm version
 Lib/fontParts/_version.py
+
+fontParts.sublime-project
+fontParts.sublime-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,3 @@ htmlcov
 
 # scm version
 Lib/fontParts/_version.py
-
-fontParts.sublime-project
-fontParts.sublime-workspace

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -801,8 +801,8 @@ class BaseContour(
         """
         Subclasses may override this method.
         """
-        return tuple([self._getitem__points(i)
-                     for i in range(self._len__points())])
+        return tuple(self._getitem__points(i)
+                     for i in range(self._len__points()))
 
     def _len__points(self):
         return self._lenPoints()
@@ -994,8 +994,8 @@ class BaseContour(
     )
 
     def _get_base_selectedSegments(self):
-        selected = tuple([normalizers.normalizeSegment(segment)
-                         for segment in self._get_selectedSegments()])
+        selected = tuple(normalizers.normalizeSegment(segment)
+                         for segment in self._get_selectedSegments())
         return selected
 
     def _get_selectedSegments(self):
@@ -1043,8 +1043,8 @@ class BaseContour(
     )
 
     def _get_base_selectedPoints(self):
-        selected = tuple([normalizers.normalizePoint(point)
-                         for point in self._get_selectedPoints()])
+        selected = tuple(normalizers.normalizePoint(point)
+                         for point in self._get_selectedPoints())
         return selected
 
     def _get_selectedPoints(self):
@@ -1092,8 +1092,8 @@ class BaseContour(
     )
 
     def _get_base_selectedBPoints(self):
-        selected = tuple([normalizers.normalizeBPoint(bPoint)
-                         for bPoint in self._get_selectedBPoints()])
+        selected = tuple(normalizers.normalizeBPoint(bPoint)
+                         for bPoint in self._get_selectedBPoints())
         return selected
 
     def _get_selectedBPoints(self):

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -1717,8 +1717,8 @@ class BaseFont(_BaseGlyphVendor,
             Subclasses may override this method.
 
         """
-        return tuple([self._getitem__guidelines(i)
-                      for i in range(self._len__guidelines())])
+        return tuple(self._getitem__guidelines(i)
+                      for i in range(self._len__guidelines()))
 
     def _len__guidelines(self) -> int:
         return self._lenGuidelines()
@@ -2232,8 +2232,8 @@ class BaseFont(_BaseGlyphVendor,
     )
 
     def _get_base_selectedLayers(self) -> Tuple[BaseLayer, ...]:
-        selected = tuple([normalizers.normalizeLayer(layer) for
-                          layer in self._get_selectedLayers()])
+        selected = tuple(normalizers.normalizeLayer(layer) for
+                          layer in self._get_selectedLayers())
         return selected
 
     def _get_selectedLayers(self) -> Tuple[BaseLayer, ...]:
@@ -2296,8 +2296,8 @@ class BaseFont(_BaseGlyphVendor,
     )
 
     def _get_base_selectedLayerNames(self) -> Tuple[str, ...]:
-        selected = tuple([normalizers.normalizeLayerName(name) for
-                          name in self._get_selectedLayerNames()])
+        selected = tuple(normalizers.normalizeLayerName(name) for
+                          name in self._get_selectedLayerNames())
         return selected
 
     def _get_selectedLayerNames(self) -> Tuple[str, ...]:
@@ -2367,8 +2367,8 @@ class BaseFont(_BaseGlyphVendor,
     )
 
     def _get_base_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:
-        selected = tuple([normalizers.normalizeGuideline(guideline) for
-                          guideline in self._get_selectedGuidelines()])
+        selected = tuple(normalizers.normalizeGuideline(guideline) for
+                          guideline in self._get_selectedGuidelines())
         return selected
 
     def _get_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1487,8 +1487,8 @@ class BaseGlyph(BaseObject,
             if baseGlyph is None:
                 baseGlyph = normalizedComponent.baseGlyph
             if normalizedComponent.identifier is not None:
-                existing = set([c.identifier for c in self.components
-                                if c.identifier is not None])
+                existing = set(c.identifier for c in self.components
+                                if c.identifier is not None)
                 if normalizedComponent.identifier not in existing:
                     identifier = normalizedComponent.identifier
         normalizedBaseGlyph = normalizers.normalizeGlyphName(baseGlyph)
@@ -1982,8 +1982,8 @@ class BaseGlyph(BaseObject,
             if color is None:
                 color = normalizedGuideline.color
             if normalizedGuideline.identifier is not None:
-                existing = set([g.identifier for g in self.guidelines
-                                if g.identifier is not None])
+                existing = set(g.identifier for g in self.guidelines
+                                if g.identifier is not None)
                 if normalizedGuideline.identifier not in existing:
                     identifier = normalizedGuideline.identifier
         normalizedPosition = normalizers.normalizeCoordinateTuple(position)

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -642,7 +642,7 @@ def normalizeComponentScale(value):
                 raise TypeError("Transformation scale tuple values must be an "
                                 ":ref:`type-int-float`, not %s."
                                 % type(value).__name__)
-        value = tuple([float(v) for v in value])
+        value = tuple(float(v) for v in value)
     return value
 
 
@@ -867,7 +867,7 @@ def normalizeBoundingBox(value):
     if value[1] > value[3]:
         raise ValueError("Bounding box yMin must be less than or equal to "
                          "yMax.")
-    return tuple([float(v) for v in value])
+    return tuple(float(v) for v in value)
 
 
 def normalizeArea(value):
@@ -930,7 +930,7 @@ def normalizeColor(value):
         if v < 0 or v > 1:
             raise ValueError("The value for the %s component (%s) is not "
                              "between 0 and 1." % (component, v))
-    return tuple([float(v) for v in value])
+    return tuple(float(v) for v in value)
 
 
 # Note
@@ -988,7 +988,7 @@ def normalizeInterpolationFactor(value):
                 raise TypeError("Interpolation factor tuple values must be an "
                                 ":ref:`type-int-float`, not %s."
                                 % type(value).__name__)
-        value = tuple([float(v) for v in value])
+        value = tuple(float(v) for v in value)
     return value
 
 
@@ -1016,7 +1016,7 @@ def normalizeTransformationMatrix(value):
             raise TypeError("Transformation matrix values must be instances "
                             "of :ref:`type-int-float`, not %s."
                             % type(v).__name__)
-    return tuple([float(v) for v in value])
+    return tuple(float(v) for v in value)
 
 
 def normalizeTransformationOffset(value):
@@ -1056,12 +1056,12 @@ def normalizeTransformationSkewAngle(value):
                 raise TypeError("Transformation skew angle tuple values must "
                                 "be an :ref:`type-int-float`, not %s."
                                 % type(value).__name__)
-        value = tuple([float(v) for v in value])
+        value = tuple(float(v) for v in value)
     for v in value:
         if abs(v) > 360:
             raise ValueError("Transformation skew angle must be between -360 "
                              "and 360.")
-    return tuple([float(v + 360) if v < 0 else float(v) for v in value])
+    return tuple(float(v + 360) if v < 0 else float(v) for v in value)
 
 
 def normalizeTransformationScale(value):
@@ -1087,7 +1087,7 @@ def normalizeTransformationScale(value):
                 raise TypeError("Transformation scale tuple values must be an "
                                 ":ref:`type-int-float`, not %s."
                                 % type(value).__name__)
-        value = tuple([float(v) for v in value])
+        value = tuple(float(v) for v in value)
     return value
 
 


### PR DESCRIPTION
In cases where removed, the comprehensions were cast to a different type, where a generator expression is more efficient.