### PR TITLE
Corrected annotation

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -2417,8 +2417,9 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         return self._getSelectedSubObjects(self.guidelines)
 
-    def _set_base_selectedGuidelines(self,
-                                     value: List[Union[BaseGuideline, int]]) -> None:
+    def _set_base_selectedGuidelines(
+        self, value: List[Union[BaseGuideline, int]]
+    ) -> None:
         normalized = []
         for guideline in value:
             normalizedGuideline: Union[BaseGuideline, int]


### PR DESCRIPTION
This adresses mypy errors raised after refactoring of `annotations.py` and annotation of `normalizers.py`.

The following errors presist, which will be collected in #775:

```zsh
font.py:64: error: Signature of "_reprContents" incompatible with supertype "BaseObject"  [override]
font.py:64: note:      Superclass:
font.py:64: note:          @classmethod
font.py:64: note:          def _reprContents(cls) -> List[str]
font.py:64: note:      Subclass:
font.py:64: note:          def _reprContents(self) -> List[str]
font.py:1901: error: Unsupported operand types for <= ("int" and "None")  [operator]
font.py:1901: note: Left operand is of type "Optional[int]"
font.py:1903: error: Argument 1 to "_removeGuideline" of "BaseFont" has incompatible type "Optional[int]"; expected "int"  [arg-type]
font.py:2063: error: Signature of "isCompatible" incompatible with supertype "InterpolationMixin"  [override]
font.py:2063: note:      Superclass:
font.py:2063: note:          def isCompatible(self, other: Any, cls: Type[Any]) -> Tuple[bool, Any]
font.py:2063: note:      Subclass:
font.py:2063: note:          def isCompatible(self, other: BaseFont) -> Tuple[bool, str]
font.py:2140: error: "str" has no attribute "fatal"  [attr-defined]
font.py:2140: error: "str" has no attribute "warning"  [attr-defined]
font.py:2141: error: "str" has no attribute "fatal"  [attr-defined]
font.py:2143: error: "str" has no attribute "warning"  [attr-defined]
```