### PR TITLE
Update file path normalizer test

### DIFF
--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -1145,7 +1145,7 @@ def normalizeFilePath(value: Union[str, Path]) -> str:
     Relative paths are resolved automatically.
 
     :param value: The file path to normalize as a :class:`str` or :class:`pathlib.Path`.
-    :return: A :class:`str` representing the normalized file path.
+    :return: A :class:`str` representing the normalized full file path.
     :raises TypeError if `value` is not a :class:`str` or :class:`pathlib.Path`.
     :raises FileNotFoundError: If the file path cannot be resolved because it does not exist.
 

--- a/Lib/fontParts/test/test_normalizers.py
+++ b/Lib/fontParts/test/test_normalizers.py
@@ -1428,6 +1428,7 @@ class TestNormalizers(unittest.TestCase):
     # normalizeFilePath
     def test_normalizeFilePath_pathlib_path(self):
         from pathlib import Path
+
         path = Path(os.getcwd(), "Test.ufo")
         self.assertIsInstance(path, Path)
         result = normalizers.normalizeFilePath(path)

--- a/Lib/fontParts/test/test_normalizers.py
+++ b/Lib/fontParts/test/test_normalizers.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from fontParts.base import normalizers
 
 
@@ -1425,16 +1426,23 @@ class TestNormalizers(unittest.TestCase):
             normalizers.normalizeGlyphNote(123)
 
     # normalizeFilePath
+    def test_normalizeFilePath_pathlib_path(self):
+        from pathlib import Path
+        path = Path(os.getcwd(), "Test.ufo")
+        self.assertIsInstance(path, Path)
+        result = normalizers.normalizeFilePath(path)
+        self.assertIsInstance(result, str)
+        self.assertEqual(result, os.path.join(os.getcwd(), "Test.ufo"))
 
     def test_normalizeFilePath_string(self):
         result = normalizers.normalizeFilePath("A")
         self.assertIsInstance(result, str)
-        self.assertEqual(result, "A")
+        self.assertEqual(result, os.path.join(os.getcwd(), "A"))
 
     def test_normalizeFilePath_emptyString(self):
         result = normalizers.normalizeFilePath("")
         self.assertIsInstance(result, str)
-        self.assertEqual(result, "")
+        self.assertEqual(result, os.getcwd())
 
     def test_normalizeFilePath_notString(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Test file path with PathLib, note in doc that return is the full file path.

@typemytype @typesupply resolving the path to a full path may be a breaking change. Would you rather it be optional (adding a `fullPath` arg defaulting to `False`)?