### PR TITLE
Document and resolve `LibValueType`

### DIFF
--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -44,6 +44,25 @@ LibValueType = Union[
     datetime.datetime,
 ]
 
+class LibValue:
+    # Documentation class for LibValueType
+    """A :class:`~fontParts.base.BaseLib` value may be one of the following 
+    *non-collection* types:
+
+    - :class:`str` 
+    - :class:`int` 
+    - :class:`float` 
+    - :class:`bool`
+    - :class:`bytes`,
+    - :class:`bytearray` 
+    - :class:`datetime.datetime`
+
+    In addition, a value may also be a :class:`list` or :class:`tuple` containing any of 
+    the types above, or a :class:`dict` mapping :class:`str` keys to values of those 
+    same types (including nested lists, tuples, or dicts).
+
+    """
+
 # Transformation
 TransformationType = Union[IntFloatType, List[IntFloatType], PairType[IntFloatType]]
 

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -44,24 +44,26 @@ LibValueType = Union[
     datetime.datetime,
 ]
 
+
 class LibValue:
     # Documentation class for LibValueType
-    """A :class:`~fontParts.base.BaseLib` value may be one of the following 
+    """A :class:`~fontParts.base.BaseLib` value may be one of the following
     *non-collection* types:
 
-    - :class:`str` 
-    - :class:`int` 
-    - :class:`float` 
+    - :class:`str`
+    - :class:`int`
+    - :class:`float`
     - :class:`bool`
     - :class:`bytes`,
-    - :class:`bytearray` 
+    - :class:`bytearray`
     - :class:`datetime.datetime`
 
-    In addition, a value may also be a :class:`list` or :class:`tuple` containing any of 
-    the types above, or a :class:`dict` mapping :class:`str` keys to values of those 
+    In addition, a value may also be a :class:`list` or :class:`tuple` containing any of
+    the types above, or a :class:`dict` mapping :class:`str` keys to values of those
     same types (including nested lists, tuples, or dicts).
 
     """
+
 
 # Transformation
 TransformationType = Union[IntFloatType, List[IntFloatType], PairType[IntFloatType]]

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -92,6 +92,10 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 autodoc_member_order = "bysource"
 autoclass_content = "both"
 
+autodoc_type_aliases = {
+    "LibValueType": "~fontParts.base.annotations.LibValue"
+}
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/documentation/source/objectref/valuetypes/index.rst
+++ b/documentation/source/objectref/valuetypes/index.rst
@@ -89,3 +89,9 @@ Immutable List
 --------------
 
 This must be an immutable, ordered iterable like a ``tuple``.
+
+
+Lib Value
+---------
+
+.. autoclass:: fontParts.base.annotations.LibValue


### PR DESCRIPTION
### Rationale 
`BaseLib` allows nested collection types (`list`, `tuple` and `dict`. Because of this, the type alias `LibValueType` has to use forward references as strings:

```python
LibValueType = Union[
    str,
    IntFloatType,
    bool,
    CollectionType["LibValueType"],
    Dict[str, "LibValueType"],
    bytes,
    bytearray,
    datetime.datetime,
]
```
Sphinx, in turn, will not resolve correctly in the generated documentation. 

### Solution
- Add a `LibValue` class to `base.annotations` purely for the purpose of documenting these types.
- Replace the type alias with a reference to this class via `autodoc_type_aliases` in `conf.py`
- Generate documentation for the `LibValue` class in `objectref/valuetypes/index.rst`.

### Alternate Name
`BaseLibValue` might be a more appropriate name for this class.
 

