### PR TITLE
Fix bug in `BaseFont.copyData`.

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -95,8 +95,8 @@ class BaseFont(
             else:
                 layer = self.newLayer(layerName)
             layer.copyData(source.getLayer(layerName))
-        for guideline in self.guidelines:
-            self.appendGuideline(guideline)
+        for guideline in source.guidelines:
+            self.appendGuideline(guideline=guideline)
         super(BaseFont, self).copyData(source)
 
     # ---------------


### PR DESCRIPTION
Annotating `fortshell` revealed a bug in copyData.

Tests of `copy` and `copyData` should probably make sure that source and target are not the same object, so that things like this gets caught.