### PR TITLE
Fix color object guideline from math glyph

### DIFF
--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1703,7 +1703,7 @@ class BaseGlyph(BaseObject,
                 a._setIdentifier(identifier)
         for guideline in mathGlyph.guidelines:
             guideColor = guideline.get("color")
-            if type(guideColor) == tuple:
+            if type(guideColor) == tuple or guideColor is None:
                 colorData = guideColor
             else:
                 try:
@@ -1713,7 +1713,7 @@ class BaseGlyph(BaseObject,
                     # it is not a defcon color object
                     # it is just a color value for a guideline
                     # we can ignore it.
-                    continue
+                    colorData = None
             g = copied.appendGuideline(
                 position=(guideline["x"], guideline["y"]),
                 angle=guideline["angle"],

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1703,17 +1703,11 @@ class BaseGlyph(BaseObject,
                 a._setIdentifier(identifier)
         for guideline in mathGlyph.guidelines:
             guideColor = guideline.get("color")
-            if type(guideColor) == tuple or guideColor is None:
-                colorData = guideColor
+            if guideColor is None:
+                colorData = None
             else:
-                try:
-                    colorData = (guideColor.r, guideColor.g, guideColor.b, guideColor.a)
-                except:
-                    # it is not a tuple
-                    # it is not a defcon color object
-                    # it is just a color value for a guideline
-                    # we can ignore it.
-                    colorData = None
+                r, g, b, a = guideColor
+                colorData = (r, g, b, a)
             g = copied.appendGuideline(
                 position=(guideline["x"], guideline["y"]),
                 angle=guideline["angle"],

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1709,8 +1709,10 @@ class BaseGlyph(BaseObject,
                 try:
                     colorData = (guideColor.r, guideColor.g, guideColor.b, guideColor.a)
                 except:
-                    # fork it
-                    print('fontParts glyph fromMathGlyph guideline color object', type(guideColor))
+                    # it is not a tuple
+                    # it is not a defcon color object
+                    # it is just a color value for a guideline
+                    # we can ignore it.
                     continue
             g = copied.appendGuideline(
                 position=(guideline["x"], guideline["y"]),

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1702,11 +1702,21 @@ class BaseGlyph(BaseObject,
             if identifier is not None:
                 a._setIdentifier(identifier)
         for guideline in mathGlyph.guidelines:
+            guideColor = guideline.get("color")
+            if type(guideColor) == tuple:
+                colorData = guideColor
+            else:
+                try:
+                    colorData = (guideColor.r, guideColor.g, guideColor.b, guideColor.a)
+                except:
+                    # fork it
+                    print('fontParts glyph fromMathGlyph guideline color object', type(guideColor))
+                    continue
             g = copied.appendGuideline(
                 position=(guideline["x"], guideline["y"]),
                 angle=guideline["angle"],
                 name=guideline.get("name"),
-                color=guideline.get("color")
+                color=colorData,
             )
             identifier = guideline.get("identifier")
             if identifier is not None:


### PR DESCRIPTION
For your consideration. This addresses issue #850.
Summary: during fromMathGlyph, a guideline can have a color that can be a defcon color object rather than a tuple. This adds some resilience without creating too many expectations or dependency on defcon.

This is a small but annoying issue that in effect requires all guidelines to be removed from source glyphs before starting calculations. 