### PR TITLE
Disable codecov upload for forks

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,7 @@ jobs:
       if: github.repository == 'robotools/fontparts'
       uses: codecov/codecov-action@v5
       with:
-        file: coverage.xml
+        files: coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: true


### PR DESCRIPTION
This avoids failing tests in forked repos due to `codecov` upload failure.
It also changes the deprecated `file` argument of `codecov/codecov-action@v5` to `files`.