### PR TITLE
Disable `codecov` upload from forks for `v1`

### DIFF
--- a/.github/workflows/lint_test.yml
+++ b/.github/workflows/lint_test.yml
@@ -85,6 +85,7 @@ jobs:
             coverage combine
             coverage xml
         - name: Upload coverage to Codecov
+          if: github.repository == 'robotools/fontparts'
           uses: codecov/codecov-action@v4
           with:
             file: coverage.xml


### PR DESCRIPTION
Same as #868, but for the `v1` branch.