### PR TITLE
Modernize type hints to py3.10+ and fix typos

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, List, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Union, List, Tuple
+from collections.abc import Callable
 
 from fontTools.misc import transform
 from fontParts.base import normalizers
@@ -48,7 +49,7 @@ class BaseAnchor(
 
     """
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = [f"({self.x}, {self.y})"]
 
         if self.name is not None:
@@ -61,7 +62,7 @@ class BaseAnchor(
     # Copy
     # ----
 
-    copyAttributes: Tuple[str, ...] = ("x", "y", "name", "color")
+    copyAttributes: tuple[str, ...] = ("x", "y", "name", "color")
 
     # -------
     # Parents
@@ -69,7 +70,7 @@ class BaseAnchor(
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph: dynamicProperty = dynamicProperty(
         "glyph",
@@ -89,13 +90,13 @@ class BaseAnchor(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for anchor already set")
@@ -121,7 +122,7 @@ class BaseAnchor(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
@@ -144,7 +145,7 @@ class BaseAnchor(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._glyph is None:
             return None
         return self.glyph.font
@@ -308,12 +309,12 @@ class BaseAnchor(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         value = self._get_index()
         value = normalizers.normalizeIndex(value)
         return value
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the native anchor's index.
 
         This is the environment implementation of the :attr:`BaseAnchor.index`
@@ -350,18 +351,18 @@ class BaseAnchor(
         """,
     )
 
-    def _get_base_name(self) -> Optional[str]:
+    def _get_base_name(self) -> str | None:
         value = self._get_name()
         if value is not None:
             value = normalizers.normalizeAnchorName(value)
         return value
 
-    def _set_base_name(self, value: Optional[str]) -> None:
+    def _set_base_name(self, value: str | None) -> None:
         if value is not None:
             value = normalizers.normalizeAnchorName(value)
         self._set_name(value)
 
-    def _get_name(self) -> Optional[str]:
+    def _get_name(self) -> str | None:
         """Get the native anchor's name.
 
         This is the environment implementation of the :attr:`BaseAnchor.name`
@@ -380,7 +381,7 @@ class BaseAnchor(
         """
         self.raiseNotImplementedError()
 
-    def _set_name(self, value: Optional[str]) -> None:
+    def _set_name(self, value: str | None) -> None:
         """Set the native anchor's name.
 
         This is the environment implementation of the :attr:`BaseAnchor.name`
@@ -419,7 +420,7 @@ class BaseAnchor(
         """,
     )
 
-    def _get_base_color(self) -> Optional[Color]:
+    def _get_base_color(self) -> Color | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
@@ -430,7 +431,7 @@ class BaseAnchor(
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:
+    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
         """Get the native anchor's color.
 
         This is the environment implementation of the :attr:`BaseAnchor.color`
@@ -449,7 +450,7 @@ class BaseAnchor(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: Optional[QuadrupleType[float]]) -> None:
+    def _set_color(self, value: QuadrupleType[float] | None) -> None:
         """Set the native anchor's color.
 
         Description
@@ -502,7 +503,7 @@ class BaseAnchor(
 
     def isCompatible(
         self, other: BaseAnchor, cls=None
-    ) -> Tuple[bool, AnchorCompatibilityReporter]:
+    ) -> tuple[bool, AnchorCompatibilityReporter]:
         """Evaluate interpolation compatibility with another anchor.
 
         :param other: The other :class:`BaseAnchor` instance to check
@@ -522,7 +523,7 @@ class BaseAnchor(
             [Warning] Anchor: "left" has name left | "right" has name right
 
         """
-        return super(BaseAnchor, self).isCompatible(other, BaseAnchor)
+        return super().isCompatible(other, BaseAnchor)
 
     def _isCompatible(
         self, other: BaseAnchor, reporter: AnchorCompatibilityReporter

--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -338,7 +338,7 @@ class BaseAnchor(
         "base_name",
         """Get or set the anchor's name.
 
-        The value must be a :class:`str` or :obj: `None`.
+        The value must be a :class:`str` or :obj:`None`.
 
         :return: A :class:`str` representing the name of the anchor, or :obj:`None`.
 

--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -95,9 +95,7 @@ class BaseAnchor(
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for anchor already set")
         if glyph is not None:

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -57,7 +57,7 @@ class LibValue:
     - :class:`int`
     - :class:`float`
     - :class:`bool`
-    - :class:`bytes`,
+    - :class:`bytes`
     - :class:`bytearray`
     - :class:`datetime.datetime`
 

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -9,31 +9,31 @@ from fontTools.pens.pointPen import AbstractPointPen
 # Generic
 T = TypeVar("T")
 
-PairType = Tuple[T, T]
-QuadrupleType = Tuple[T, T, T, T]
-QuintupleType = Tuple[T, T, T, T, T]
-SextupleType = Tuple[T, T, T, T, T, T]
-CollectionType = Union[List[T], Tuple[T, ...]]
-PairCollectionType = Union[List[T], PairType[T]]
-QuadrupleCollectionType = Union[List[T], QuadrupleType[T]]
-SextupleCollectionType = Union[List[T], SextupleType[T]]
+PairType = tuple[T, T]
+QuadrupleType = tuple[T, T, T, T]
+QuintupleType = tuple[T, T, T, T, T]
+SextupleType = tuple[T, T, T, T, T, T]
+CollectionType = Union[list[T], tuple[T, ...]]
+PairCollectionType = Union[list[T], PairType[T]]
+QuadrupleCollectionType = Union[list[T], QuadrupleType[T]]
+SextupleCollectionType = Union[list[T], SextupleType[T]]
 
 # Builtins
 IntFloatType = Union[int, float]
 
 # Compatibility
-DiffType = List[Tuple[int, Optional[str], Optional[str]]]
+DiffType = list[tuple[int, Optional[str], Optional[str]]]
 
 # Pens
 PenType = AbstractPen
 PointPenType = AbstractPointPen
 
 # Mapping
-CharacterMappingType = Dict[int, Tuple[str, ...]]
-ReverseComponentMappingType = Dict[str, Tuple[str, ...]]
+CharacterMappingType = dict[int, tuple[str, ...]]
+ReverseComponentMappingType = dict[str, tuple[str, ...]]
 
 # Kerning
-KerningDictType = Dict[PairType[str], PairType[str]]
+KerningDictType = dict[PairType[str], PairType[str]]
 
 # Lib
 LibValueType = Union[
@@ -41,7 +41,7 @@ LibValueType = Union[
     IntFloatType,
     bool,
     CollectionType["LibValueType"],
-    Dict[str, "LibValueType"],
+    dict[str, "LibValueType"],
     bytes,
     bytearray,
     datetime.datetime,
@@ -69,7 +69,7 @@ class LibValue:
 
 
 # Transformation
-TransformationType = Union[IntFloatType, List[IntFloatType], PairType[IntFloatType]]
+TransformationType = Union[IntFloatType, list[IntFloatType], PairType[IntFloatType]]
 
 # Interpolation
 InterpolatableType = TypeVar("InterpolatableType", bound="Interpolatable")

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+from collections.abc import Callable
 from fontTools.misc import transform
 
 from fontParts.base.base import (
@@ -39,7 +40,7 @@ class BaseBPoint(
 ):
     """Represent the basis for a bPoint object."""
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = [f"{self.type}", f"anchor='({self.anchor[0]}, {self.anchor[1]})'"]
         return contents
 
@@ -64,7 +65,7 @@ class BaseBPoint(
 
     # identifier
 
-    def _get_identifier(self) -> Optional[str]:
+    def _get_identifier(self) -> str | None:
         """Get the native bPoint's unique identifier.
 
         This is the environment implementation of :attr:`BaseBPoint.identifier`.
@@ -100,7 +101,7 @@ class BaseBPoint(
 
     _segment: dynamicProperty = dynamicProperty("base_segment")
 
-    def _get_base_segment(self) -> Optional[BaseSegment]:
+    def _get_base_segment(self) -> BaseSegment | None:
         point = self._point
         for segment in self.contour.segments:
             if segment.onCurve == point:
@@ -109,7 +110,7 @@ class BaseBPoint(
 
     _nextSegment: dynamicProperty = dynamicProperty("base_nextSegment")
 
-    def _get_base_nextSegment(self) -> Optional[BaseSegment]:
+    def _get_base_nextSegment(self) -> BaseSegment | None:
         contour = self.contour
         if contour is None:
             return None
@@ -123,7 +124,7 @@ class BaseBPoint(
 
     # Contour
 
-    _contour: Optional[Callable[[], BaseContour]] = None
+    _contour: Callable[[], BaseContour] | None = None
 
     contour = dynamicProperty(
         "contour",
@@ -143,13 +144,13 @@ class BaseBPoint(
         """,
     )
 
-    def _get_contour(self) -> Optional[BaseContour]:
+    def _get_contour(self) -> BaseContour | None:
         if self._contour is None:
             return None
         return self._contour()
 
     def _set_contour(
-        self, contour: Optional[Union[BaseContour, Callable[[], BaseContour]]]
+        self, contour: BaseContour | Callable[[], BaseContour] | None
     ) -> None:
         if self._contour is not None:
             raise AssertionError("contour for bPoint already set")
@@ -177,7 +178,7 @@ class BaseBPoint(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._contour is None:
             return None
         return self.contour.glyph
@@ -200,7 +201,7 @@ class BaseBPoint(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._contour is None:
             return None
         return self.glyph.layer
@@ -223,7 +224,7 @@ class BaseBPoint(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._contour is None:
             return None
         return self.glyph.font
@@ -361,7 +362,7 @@ class BaseBPoint(
         segment = self._segment
         if segment.type == "move" and value != (0, 0):
             raise FontPartsError(
-                ("Cannot set the bcpIn for the first point in an open contour.")
+                "Cannot set the bcpIn for the first point in an open contour."
             )
 
         offCurves = segment.offCurve
@@ -449,7 +450,7 @@ class BaseBPoint(
         nextSegment = self._nextSegment
         if nextSegment.type == "move" and value != (0, 0):
             raise FontPartsError(
-                ("Cannot set the bcpOut for the last point in an open contour.")
+                "Cannot set the bcpOut for the last point in an open contour."
             )
         else:
             offCurves = nextSegment.offCurve
@@ -584,14 +585,14 @@ class BaseBPoint(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         if self.contour is None:
             return None
         value = self._get_index()
         value = normalizers.normalizeIndex(value)
         return value
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the index of the native bPoint.
 
         This is the environment implementation of the :attr:`BaseBPoint.index`

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -237,11 +237,11 @@ class BaseBPoint(
 
     anchor: dynamicProperty = dynamicProperty(
         "base_anchor",
-        """Get or set the the bPoint's anchor point.
+        """Get or set the bPoint's anchor point.
 
-        The value must be a :ref:`type-coordianate`.
+        The value must be a :ref:`type-coordinate`.
 
-        :return: a :ref:`type-coordianate` representing the anchor point of the bPoint.
+        :return: a :ref:`type-coordinate` representing the anchor point of the bPoint.
 
         """,
     )
@@ -256,12 +256,12 @@ class BaseBPoint(
         self._set_anchor(value)
 
     def _get_anchor(self) -> PairType[IntFloatType]:
-        """Get the the bPoint's anchor point.
+        """Get the bPoint's anchor point.
 
         This is the environment implementation of the :attr:`BaseBPoint.anchor`
         property getter.
 
-        :return: a :ref:`type-coordianate` representing the anchor point of the
+        :return: a :ref:`type-coordinate` representing the anchor point of the
             bPoint. The value will be normalized
             with :func:`normalizers.normalizeCoordinateTuple`.
 
@@ -274,12 +274,12 @@ class BaseBPoint(
         return (point.x, point.y)
 
     def _set_anchor(self, value: PairCollectionType[IntFloatType]) -> None:
-        """Set the the bPoint's anchor point.
+        """Set the bPoint's anchor point.
 
         This is the environment implementation of the :attr:`BaseBPoint.anchor`
         property setter.
 
-        :param value: The anchor point to set as a :ref:`type-coordianate`.
+        :param value: The anchor point to set as a :ref:`type-coordinate`.
             The value will have been normalized
             with :func:`normalizers.normalizeCoordinateTuple`.
 
@@ -348,7 +348,7 @@ class BaseBPoint(
         property setter.
 
         :param value: The incoming off-curve to set as
-            a :ref:`type-coordianate`. The value will have been normalized
+            a :ref:`type-coordinate`. The value will have been normalized
             with :func:`normalizers.normalizeCoordinateTuple`.
         :raises FontPartsError: When attempting to set the incoming off-curve
             for a the first point in an open contour.
@@ -435,7 +435,7 @@ class BaseBPoint(
         property setter.
 
         :param value: The outgoing off-curve to set as
-            a :ref:`type-coordianate`. The value will have been normalized
+            a :ref:`type-coordinate`. The value will have been normalized
             with :func:`normalizers.normalizeCoordinateTuple`.
         :raises FontPartsError: When attempting to set the outgoing off-curve
             for a the last point in an open contour.
@@ -684,10 +684,10 @@ def relativeBCPIn(
     """convert absolute incoming bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
-        BCP value as a :ref:`type-coordinate.
+        BCP value as a :ref:`type-coordinate`.
     :param BCPIn: The absolute incoming BCP value to be converted as
-        a :ref:`type-coordinate.
-    :return: The relative position of the incoming BCP as a :ref:`type-coordinate.
+        a :ref:`type-coordinate`.
+    :return: The relative position of the incoming BCP as a :ref:`type-coordinate`.
 
     """
     return (BCPIn[0] - anchor[0], BCPIn[1] - anchor[1])
@@ -699,10 +699,10 @@ def absoluteBCPIn(
     """convert relative incoming bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value
-        is measured as a :ref:`type-coordinate.
+        is measured as a :ref:`type-coordinate`.
     :param BCPIn: The relative incoming BCP value to be converted as
-        a :ref:`type-coordinate.
-    :return: The absolute position of the incoming BCP as a :ref:`type-coordinate.
+        a :ref:`type-coordinate`.
+    :return: The absolute position of the incoming BCP as a :ref:`type-coordinate`.
 
     """
     return (BCPIn[0] + anchor[0], BCPIn[1] + anchor[1])
@@ -714,10 +714,10 @@ def relativeBCPOut(
     """convert absolute outgoing bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
-        BCP value as a :ref:`type-coordinate.
+        BCP value as a :ref:`type-coordinate`.
     :param BCPOut: The absolute outgoing BCP value to be converted as
-        a :ref:`type-coordinate.
-    :return: The relative position of the outgoing BCP as a :ref:`type-coordinate.
+        a :ref:`type-coordinate`.
+    :return: The relative position of the outgoing BCP as a :ref:`type-coordinate`.
 
     """
     return (BCPOut[0] - anchor[0], BCPOut[1] - anchor[1])
@@ -729,10 +729,10 @@ def absoluteBCPOut(
     """convert relative outgoing bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value
-        is measured as a :ref:`type-coordinate.
+        is measured as a :ref:`type-coordinate`.
     :param BCPOut: The relative outgoing BCP value to be converted as
-        a :ref:`type-coordinate.
-    :return: The absolute position of the outgoing BCP as a :ref:`type-coordinate.
+        a :ref:`type-coordinate`.
+    :return: The absolute position of the outgoing BCP as a :ref:`type-coordinate`.
 
     """
     return (BCPOut[0] + anchor[0], BCPOut[1] + anchor[1])

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -4,10 +4,7 @@ from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
-    Iterable,
-    Iterator,
     List,
     NoReturn,
     Optional,
@@ -16,6 +13,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from collections.abc import Callable, Iterable, Iterator
 from copy import deepcopy
 import math
 from collections.abc import MutableMapping
@@ -125,13 +123,13 @@ class dynamicProperty:
 
     """
 
-    def __init__(self, name: str, doc: Optional[str] = None) -> None:
+    def __init__(self, name: str, doc: str | None = None) -> None:
         self.name = name
         self.__doc__ = doc
         self.getterName = "_get_" + name
         self.setterName = "_set_" + name
 
-    def __get__(self, obj: Any, cls: Type[Any]) -> Any:
+    def __get__(self, obj: Any, cls: type[Any]) -> Any:
         getter = getattr(obj, self.getterName, None)
         if getter is not None:
             return getter()
@@ -240,7 +238,7 @@ class BaseObject(Generic[BaseObjectType]):
             contentString = ""
         return f"<{self.__class__.__name__}{contentString} at {hex(id(self))}>"
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         """Provide a list of strings for inclusion in :meth:`BaseObject.__repr__.
 
         :return: A :class:`list` of :class:`str` items.
@@ -311,8 +309,8 @@ class BaseObject(Generic[BaseObjectType]):
     # Copy
     # ----
 
-    copyClass: Optional[Type[Any]] = None
-    copyAttributes: Tuple[str, ...] = ()
+    copyClass: type[Any] | None = None
+    copyAttributes: tuple[str, ...] = ()
 
     def copy(self: BaseObjectType) -> BaseObjectType:
         """Copy the current object into a new object of the same type.
@@ -414,7 +412,7 @@ class BaseItems(Generic[KeyType, ValueType]):
     def __init__(self, mapping: BaseDict[KeyType, ValueType]) -> None:
         self._mapping = mapping
 
-    def __contains__(self, item: Tuple[KeyType, ValueType]) -> bool:
+    def __contains__(self, item: tuple[KeyType, ValueType]) -> bool:
         """Check if a key-value pair exists in the mapping.
 
         :param item: The key-value pair to check for existence as a :class:`tuple`.
@@ -428,7 +426,7 @@ class BaseItems(Generic[KeyType, ValueType]):
         )
         return normalizedItem in self._mapping._normalizeItems()
 
-    def __iter__(self) -> Iterator[Tuple[KeyType, ValueType]]:
+    def __iter__(self) -> Iterator[tuple[KeyType, ValueType]]:
         """Return an iterator over the key-value pairs in the mapping.
 
         This method yields each item one by one, removing it from the list of
@@ -583,8 +581,8 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
 
     """
 
-    keyNormalizer: Optional[Callable[[KeyType], KeyType]] = None
-    valueNormalizer: Optional[Callable[[ValueType], ValueType]] = None
+    keyNormalizer: Callable[[KeyType], KeyType] | None = None
+    valueNormalizer: Callable[[ValueType], ValueType] | None = None
 
     def _normalizeKey(self, key: KeyType) -> KeyType:
         keyNormalizer = type(self).keyNormalizer
@@ -594,7 +592,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         valueNormalizer = type(self).valueNormalizer
         return valueNormalizer(value) if valueNormalizer is not None else value
 
-    def _normalizeItems(self) -> List[Tuple[KeyType, ValueType]]:
+    def _normalizeItems(self) -> list[tuple[KeyType, ValueType]]:
         items = self._items()
         return [(self._normalizeKey(k), self._normalizeValue(v)) for (k, v) in items]
 
@@ -609,7 +607,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
             to copy data.
 
         """
-        super(BaseDict, self).copyData(source)
+        super().copyData(source)
         if isinstance(source, MutableMapping):
             self.update(source)
 
@@ -803,8 +801,8 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         self.raiseNotImplementedError()
 
     def get(
-        self, key: KeyType, default: Optional[ValueType] = None
-    ) -> Optional[ValueType]:
+        self, key: KeyType, default: ValueType | None = None
+    ) -> ValueType | None:
         """Get the value for a given key in the object.
 
         If the given key is not found, The specified `default` will be returned.
@@ -823,7 +821,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
             value = self._normalizeValue(value)
         return value
 
-    def _get(self, key: KeyType, default: Optional[ValueType]) -> Optional[ValueType]:
+    def _get(self, key: KeyType, default: ValueType | None) -> ValueType | None:
         """Get the value for a given key in the native object.
 
         This is the environment implementation of :meth:`BaseDict.get`.
@@ -871,8 +869,8 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         self.raiseNotImplementedError()
 
     def pop(
-        self, key: KeyType, default: Optional[ValueType] = None
-    ) -> Optional[ValueType]:
+        self, key: KeyType, default: ValueType | None = None
+    ) -> ValueType | None:
         """Remove a key from the object and return it's value.
 
         If the given key is not found, The specified `default` will be returned.
@@ -892,7 +890,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
             value = self._normalizeValue(value)
         return value
 
-    def _pop(self, key: KeyType, default: Optional[ValueType]) -> Optional[ValueType]:
+    def _pop(self, key: KeyType, default: ValueType | None) -> ValueType | None:
         """Remove a key from the native object and return it's value.
 
         This is the environment implementation of :meth:`BaseDict.pop`.
@@ -938,8 +936,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
             Subclasses may override this method.
 
         """
-        for key in self.keys():
-            yield key
+        yield from self.keys()
 
     def update(self, other: MutableMapping[KeyType, ValueType]) -> None:
         """Update the current object instance with key-value pairs from another.
@@ -1003,7 +1000,7 @@ class TransformationMixin(ABC):
     def transformBy(
         self,
         matrix: SextupleCollectionType[IntFloatType],
-        origin: Optional[PairCollectionType[IntFloatType]] = None,
+        origin: PairCollectionType[IntFloatType] | None = None,
     ) -> None:
         """Transform the object according to the given matrix.
 
@@ -1088,7 +1085,7 @@ class TransformationMixin(ABC):
     def scaleBy(
         self,
         value: TransformationType,
-        origin: Optional[PairCollectionType[IntFloatType]] = None,
+        origin: PairCollectionType[IntFloatType] | None = None,
     ) -> None:
         """Scale the object according to the given values.
 
@@ -1141,7 +1138,7 @@ class TransformationMixin(ABC):
     def rotateBy(
         self,
         value: IntFloatType,
-        origin: Optional[PairCollectionType[IntFloatType]] = None,
+        origin: PairCollectionType[IntFloatType] | None = None,
     ) -> None:
         """Rotate the object by the specified value.
 
@@ -1190,7 +1187,7 @@ class TransformationMixin(ABC):
     def skewBy(
         self,
         value: TransformationType,
-        origin: Optional[PairCollectionType[IntFloatType]] = None,
+        origin: PairCollectionType[IntFloatType] | None = None,
     ) -> None:
         """Skew the object by the given value.
 
@@ -1264,9 +1261,9 @@ class InterpolationMixin(ABC):
     # Compatibility
     # -------------
 
-    compatibilityReporterClass: Optional[Type[Any]] = None
+    compatibilityReporterClass: type[Any] | None = None
 
-    def isCompatible(self, other: Any, cls: Type[Any]) -> Tuple[bool, Any]:
+    def isCompatible(self, other: Any, cls: type[Any]) -> tuple[bool, Any]:
         """Evaluate interpolation compatibility with another object.
 
         :param other: The other object instance to check compatibility with.
@@ -1388,7 +1385,7 @@ class SelectionMixin(ABC):
     # Sub-Objects
     # -----------
     @classmethod
-    def _getSelectedSubObjects(cls, subObjects: Any) -> Tuple[Any]:
+    def _getSelectedSubObjects(cls, subObjects: Any) -> tuple[Any]:
         selected = tuple(obj for obj in subObjects if obj.selected)
         return selected
 
@@ -1544,13 +1541,13 @@ class IdentifierMixin(ABC):
         """,
     )
 
-    def _get_base_identifier(self) -> Optional[str]:
+    def _get_base_identifier(self) -> str | None:
         value = self._get_identifier()
         if value is not None:
             value = normalizers.normalizeIdentifier(value)
         return value
 
-    def _get_identifier(self) -> Optional[str]:  # type: ignore[return]
+    def _get_identifier(self) -> str | None:  # type: ignore[return]
         """Get the native object's unique identifier.
 
         This is the environment implementation of :attr:`IdentifierMixin.identifier`.
@@ -1650,7 +1647,7 @@ class FuzzyNumber:
     def __repr__(self) -> str:
         return f"[{self.value:f} {self.threshold:f}]"
 
-    def __lt__(self, other: Union[FuzzyNumber, IntFloatType]) -> bool:
+    def __lt__(self, other: FuzzyNumber | IntFloatType) -> bool:
         if hasattr(other, "value"):
             if abs(self.value - other.value) < self.threshold:
                 return False

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -800,9 +800,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         """
         self.raiseNotImplementedError()
 
-    def get(
-        self, key: KeyType, default: ValueType | None = None
-    ) -> ValueType | None:
+    def get(self, key: KeyType, default: ValueType | None = None) -> ValueType | None:
         """Get the value for a given key in the object.
 
         If the given key is not found, The specified `default` will be returned.
@@ -868,9 +866,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         """
         self.raiseNotImplementedError()
 
-    def pop(
-        self, key: KeyType, default: ValueType | None = None
-    ) -> ValueType | None:
+    def pop(self, key: KeyType, default: ValueType | None = None) -> ValueType | None:
         """Remove a key from the object and return it's value.
 
         If the given key is not found, The specified `default` will be returned.

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -432,7 +432,7 @@ class BaseItems(Generic[KeyType, ValueType]):
         This method yields each item one by one, removing it from the list of
         keys after it is yielded.
 
-        :returns: An iterator over the mapping's key-value pairs.
+        :return: An iterator over the mapping's key-value pairs.
 
         """
         return iter(self._mapping._normalizeItems())
@@ -487,7 +487,7 @@ class BaseKeys(Generic[KeyType]):
         This method yields each key one by one, removing it from the list of
         keys after it is yielded.
 
-        :returns: An iterator over the mapping's keys.
+        :return: An iterator over the mapping's keys.
 
         """
         return (k for k, _ in self._mapping._normalizeItems())
@@ -551,7 +551,7 @@ class BaseValues(Generic[ValueType]):
         This method yields each value one by one, removing it from the list of
         values after it is yielded.
 
-        :returns: An iterator over the mapping's values.
+        :return: An iterator over the mapping's values.
 
         """
         return (v for _, v in self._mapping._normalizeItems())
@@ -915,7 +915,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
         This method yields each key one by one, removing it from the list of
         keys after it is yielded.
 
-        :returns: An iterator over the object's keys.
+        :return: An iterator over the object's keys.
 
         """
         return self._iter()
@@ -925,7 +925,7 @@ class BaseDict(BaseObject, Generic[KeyType, ValueType]):
 
         This is the environment implementation of :meth:`BaseDict.__iter__`.
 
-        :returns: An iterator over the object's keys.
+        :return: An iterator over the object's keys.
 
         .. note::
 

--- a/Lib/fontParts/base/color.py
+++ b/Lib/fontParts/base/color.py
@@ -14,7 +14,7 @@ class Color(tuple):
     """
 
     def __new__(
-        cls, *args: Union[IntFloatType, QuadrupleCollectionType[IntFloatType]]
+        cls, *args: IntFloatType | QuadrupleCollectionType[IntFloatType]
     ) -> Color:
         value = args[0] if len(args) == 1 else args
         normalizedValue = normalizeColor(value)  # type: ignore[arg-type]

--- a/Lib/fontParts/base/compatibility.py
+++ b/Lib/fontParts/base/compatibility.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, List, Sequence
+from typing import TYPE_CHECKING, Any, List
+from collections.abc import Sequence
 from _collections_abc import Callable
 
 from fontParts.base.base import dynamicProperty
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 # ----
 
 
-class BaseCompatibilityReporter(object):
+class BaseCompatibilityReporter:
     objectName = "Base"
 
     def __init__(self, obj1: BaseObject, obj2: BaseObject) -> None:
@@ -96,7 +97,7 @@ class BaseCompatibilityReporter(object):
         reporters: Sequence[BaseCompatibilityReporter],
         showOK: bool = True,
         showWarnings: bool = True,
-    ) -> List[str]:
+    ) -> list[str]:
         report = []
         for reporter in reporters:
             if showOK or reporter.fatal or (showWarnings and reporter.warning):
@@ -118,9 +119,9 @@ class BaseCompatibilityReporter(object):
     def reportOrderDifference(
         subObjectName: str,
         object1Name: str,
-        object1Order: List[str],
+        object1Order: list[str],
         object2Name: str,
-        object2Order: List[str],
+        object2Order: list[str],
     ) -> str:
         text = f"{object1Name} has {subObjectName} ordered {object1Order} | {object2Name} has {object2Order}"
         return text
@@ -144,14 +145,14 @@ class FontCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Font"
 
     def __init__(self, font1: BaseFont, font2: BaseFont) -> None:
-        super(FontCompatibilityReporter, self).__init__(font1, font2)
+        super().__init__(font1, font2)
         self.guidelineCountDifference = False
         self.layerCountDifference = False
-        self.guidelinesMissingFromFont2: List[str] = []
-        self.guidelinesMissingInFont1: List[str] = []
-        self.layersMissingFromFont2: List[str] = []
-        self.layersMissingInFont1: List[str] = []
-        self.layers: List[LayerCompatibilityReporter] = []
+        self.guidelinesMissingFromFont2: list[str] = []
+        self.guidelinesMissingInFont1: list[str] = []
+        self.layersMissingFromFont2: list[str] = []
+        self.layersMissingInFont1: list[str] = []
+        self.layers: list[LayerCompatibilityReporter] = []
 
     font1 = dynamicProperty("object1")
     font1Name = dynamicProperty("object1Name")
@@ -230,11 +231,11 @@ class LayerCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Layer"
 
     def __init__(self, layer1: BaseLayer, layer2: BaseLayer) -> None:
-        super(LayerCompatibilityReporter, self).__init__(layer1, layer2)
+        super().__init__(layer1, layer2)
         self.glyphCountDifference = False
-        self.glyphsMissingFromLayer2: List[str] = []
-        self.glyphsMissingInLayer1: List[str] = []
-        self.glyphs: List[GlyphCompatibilityReporter] = []
+        self.glyphsMissingFromLayer2: list[str] = []
+        self.glyphsMissingInLayer1: list[str] = []
+        self.glyphs: list[GlyphCompatibilityReporter] = []
 
     layer1 = dynamicProperty("object1")
     layer1Name = dynamicProperty("object1Name")
@@ -288,22 +289,22 @@ class GlyphCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Glyph"
 
     def __init__(self, glyph1: BaseGlyph, glyph2: BaseGlyph) -> None:
-        super(GlyphCompatibilityReporter, self).__init__(glyph1, glyph2)
+        super().__init__(glyph1, glyph2)
         self.contourCountDifference = False
         self.componentCountDifference = False
         self.guidelineCountDifference = False
         self.anchorDifferences: DiffType = []
         self.anchorCountDifference = False
         self.anchorOrderDifference = False
-        self.anchorsMissingFromGlyph1: List[str] = []
-        self.anchorsMissingFromGlyph2: List[str] = []
+        self.anchorsMissingFromGlyph1: list[str] = []
+        self.anchorsMissingFromGlyph2: list[str] = []
         self.componentDifferences: DiffType = []
         self.componentOrderDifference = False
-        self.componentsMissingFromGlyph1: List[str] = []
-        self.componentsMissingFromGlyph2: List[str] = []
-        self.guidelinesMissingFromGlyph1: List[str] = []
-        self.guidelinesMissingFromGlyph2: List[str] = []
-        self.contours: List[ContourCompatibilityReporter] = []
+        self.componentsMissingFromGlyph1: list[str] = []
+        self.componentsMissingFromGlyph2: list[str] = []
+        self.guidelinesMissingFromGlyph1: list[str] = []
+        self.guidelinesMissingFromGlyph2: list[str] = []
+        self.contours: list[ContourCompatibilityReporter] = []
 
     glyph1 = dynamicProperty("object1")
     glyph1Name = dynamicProperty("object1Name")
@@ -442,11 +443,11 @@ class ContourCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Contour"
 
     def __init__(self, contour1: BaseContour, contour2: BaseContour) -> None:
-        super(ContourCompatibilityReporter, self).__init__(contour1, contour2)
+        super().__init__(contour1, contour2)
         self.openDifference = False
         self.directionDifference = False
         self.segmentCountDifference = False
-        self.segments: List[SegmentCompatibilityReporter] = []
+        self.segments: list[SegmentCompatibilityReporter] = []
 
     contour1 = dynamicProperty("object1")
     contour1Name = dynamicProperty("object1Name")
@@ -499,7 +500,7 @@ class SegmentCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Segment"
 
     def __init__(self, contour1: BaseContour, contour2: BaseContour) -> None:
-        super(SegmentCompatibilityReporter, self).__init__(contour1, contour2)
+        super().__init__(contour1, contour2)
         self.typeDifference = False
 
     segment1 = dynamicProperty("object1")
@@ -530,7 +531,7 @@ class ComponentCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Component"
 
     def __init__(self, component1: BaseComponent, component2: BaseComponent) -> None:
-        super(ComponentCompatibilityReporter, self).__init__(component1, component2)
+        super().__init__(component1, component2)
         self.baseDifference = False
 
     component1 = dynamicProperty("object1")
@@ -561,7 +562,7 @@ class AnchorCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Anchor"
 
     def __init__(self, anchor1: BaseAnchor, anchor2: BaseAnchor) -> None:
-        super(AnchorCompatibilityReporter, self).__init__(anchor1, anchor2)
+        super().__init__(anchor1, anchor2)
         self.nameDifference = False
 
     anchor1 = dynamicProperty("object1")
@@ -592,7 +593,7 @@ class GuidelineCompatibilityReporter(BaseCompatibilityReporter):
     objectName = "Guideline"
 
     def __init__(self, guideline1: BaseGuideline, guideline2: BaseGuideline) -> None:
-        super(GuidelineCompatibilityReporter, self).__init__(guideline1, guideline2)
+        super().__init__(guideline1, guideline2)
         self.nameDifference = False
 
     guideline1 = dynamicProperty("object1")

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -286,9 +286,9 @@ class BaseComponent(
         "base_offset",
         """Get or set the component's offset.
 
-        The value must be a :ref:`type-coordinate.`
+        The value must be a :ref:`type-coordinate`.
 
-        :return: A :ref:`type-coordinate.` representing the offset of the component.
+        :return: A :ref:`type-coordinate` representing the offset of the component.
 
         """,
     )
@@ -308,7 +308,7 @@ class BaseComponent(
         This is the environment implementation of the :attr:`BaseComponent.offset`
         property getter.
 
-        :return: A :ref:`type-coordinate.` representing the offset of the component.
+        :return: A :ref:`type-coordinate` representing the offset of the component.
             The value will be normalized
             with :func:`normalizers.normalizeTransformationOffset`.
 
@@ -326,7 +326,7 @@ class BaseComponent(
         This is the environment implementation of the :attr:`BaseComponent.offset`
         property setter.
 
-        :param value: The offset to set as a :ref:`type-coordinate.`. The value will
+        :param value: The offset to set as a :ref:`type-coordinate`. The value will
             have been normalized with :func:`normalizers.normalizeTransformationOffset`.
 
         .. note::

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from collections.abc import Callable
 
 from fontTools.misc import transform
 from fontTools.pens.pointInsidePen import PointInsidePen
@@ -50,9 +51,9 @@ class BaseComponent(
 
     """
 
-    copyAttributes: Tuple[str, str] = ("baseGlyph", "transformation")
+    copyAttributes: tuple[str, str] = ("baseGlyph", "transformation")
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = [
             f"baseGlyph='{self.baseGlyph}'",
             f"offset='({self.offset[0]}, {self.offset[1]})'",
@@ -68,7 +69,7 @@ class BaseComponent(
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph: dynamicProperty = dynamicProperty(
         "glyph",
@@ -88,13 +89,13 @@ class BaseComponent(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for component already set")
@@ -120,7 +121,7 @@ class BaseComponent(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
@@ -143,7 +144,7 @@ class BaseComponent(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._glyph is None:
             return None
         return self.glyph.font
@@ -167,7 +168,7 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_baseGlyph(self) -> Optional[str]:
+    def _get_base_baseGlyph(self) -> str | None:
         value = self._get_baseGlyph()
         # if the component does not belong to a layer,
         # it is allowed to have None as its baseGlyph
@@ -181,7 +182,7 @@ class BaseComponent(
         value = normalizers.normalizeGlyphName(value)
         self._set_baseGlyph(value)
 
-    def _get_baseGlyph(self) -> Optional[str]:
+    def _get_baseGlyph(self) -> str | None:
         """Get the name of the glyph referenced by the native component.
 
         This is the environment implementation of the :attr:`BaseComponent.baseGlyph`
@@ -422,7 +423,7 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         glyph = self.glyph
         if glyph is None:
             return None
@@ -445,7 +446,7 @@ class BaseComponent(
             value = componentCount
         self._set_index(value)
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the index of the native contour.
 
         This is the environment implementation of the :attr:`BaseComponent.index`
@@ -632,7 +633,7 @@ class BaseComponent(
 
     def isCompatible(
         self, other: BaseComponent, cls=None
-    ) -> Tuple[bool, ComponentCompatibilityReporter]:
+    ) -> tuple[bool, ComponentCompatibilityReporter]:
         """Evaluate interpolation compatibility with another component.
 
         :param other: The other :class:`BaseComponent` instance to check
@@ -652,7 +653,7 @@ class BaseComponent(
             [Warning] Component: "A" has name A | "B" has name B
 
         """
-        return super(BaseComponent, self).isCompatible(other, BaseComponent)
+        return super().isCompatible(other, BaseComponent)
 
     def _isCompatible(
         self, other: BaseComponent, reporter: ComponentCompatibilityReporter

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -94,9 +94,7 @@ class BaseComponent(
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for component already set")
         if glyph is not None:

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -867,7 +867,7 @@ class BaseContour(
 
     segments: dynamicProperty = dynamicProperty(
         "segments",
-        """Get the countour's segments.
+        """Get the contour's segments.
 
         This property is read-only.
 
@@ -882,7 +882,7 @@ class BaseContour(
     )
 
     def _get_segments(self) -> tuple[BaseSegment, ...]:
-        """Get the native countour's segments.
+        """Get the native contour's segments.
 
         This is the environment implementation of the :attr:`BaseContour.segments`
         property getter.
@@ -1496,7 +1496,7 @@ class BaseContour(
         This is the environment implementation of :meth:`BaseContour.removeBPoint`.
 
         :param index: The index representing the :class:`BaseBPoint` subclass
-            instance to remove as an :class:`int. The value will have been
+            instance to remove as an :class:`int`. The value will have been
             normalized with :func:`normalizers.normalizeIndex`.
         :param \**kwargs: Additional keyword arguments.
 
@@ -1584,7 +1584,7 @@ class BaseContour(
         r"""Get the given point from the native contour.
 
         :param index: The index representing the :class:`BaseBPoint` subclass
-            instance to retrieve as an :class:`int. The value will have been
+            instance to retrieve as an :class:`int`. The value will have been
             normalized with :func:`normalizers.normalizeIndex`.
         :param \**kwargs: Additional keyword arguments.
         :return: A :class:`BasePoint` subclass instance.
@@ -1763,7 +1763,7 @@ class BaseContour(
         environment supports such functionality.
 
         :param point: The point to remove as a :class:`BasePoint` instance,
-            or an :class:`int` representing the points's index.
+            or an :class:`int` representing the point's index.
         :param preserveCurve: A :class:`bool` indicating whether to preserve
             the curve's shape after the point is removed. Defaults to :obj:`False`.
         :raises ValueError: If the point index is out of range or if the
@@ -1791,7 +1791,7 @@ class BaseContour(
         This is the environment implementation of :meth:`BaseContour.removePoint`.
 
         :param index: The index representing the :class:`BasePoint` subclass
-            instance to remove as an :class:`int. The value will have been
+            instance to remove as an :class:`int`. The value will have been
             normalized with :func:`normalizers.normalizeIndex`.
         :param preserveCurve: A :class:`bool` indicating whether to preserve
             the curve's shape after the point is removed. The value will have been

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -3,8 +3,6 @@ from typing import (
     TYPE_CHECKING,
     cast,
     Any,
-    Callable,
-    Iterator,
     List,
     Optional,
     Tuple,
@@ -12,6 +10,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from collections.abc import Callable, Iterator
 
 from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
@@ -66,10 +65,10 @@ class BaseContour(
 
     """
 
-    segmentClass: Optional[Type[BaseSegment]] = None
-    bPointClass: Optional[Type[BaseBPoint]] = None
+    segmentClass: type[BaseSegment] | None = None
+    bPointClass: type[BaseBPoint] | None = None
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.identifier is not None:
             contents.append(f"identifier='{self.identifier!r}'")
@@ -95,7 +94,7 @@ class BaseContour(
             >>> contour.copyData(sourceContour)
 
         """
-        super(BaseContour, self).copyData(source)
+        super().copyData(source)
         for sourcePoint in source.points:
             self.appendPoint((0, 0))
             selfPoint = self.points[-1]
@@ -107,7 +106,7 @@ class BaseContour(
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph: dynamicProperty = dynamicProperty(
         "glyph",
@@ -127,13 +126,13 @@ class BaseContour(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for contour already set")
@@ -159,7 +158,7 @@ class BaseContour(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._glyph is None:
             return None
         return self.glyph.font
@@ -182,7 +181,7 @@ class BaseContour(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
@@ -213,7 +212,7 @@ class BaseContour(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         glyph = self.glyph
         if glyph is None:
             return None
@@ -235,7 +234,7 @@ class BaseContour(
             normalizedValue = contourCount
         self._set_index(normalizedValue)
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the index of the native contour.
 
         This is the environment implementation of the :attr:`BaseContour.index`
@@ -493,7 +492,7 @@ class BaseContour(
 
     def isCompatible(
         self, other: BaseContour, cls=None
-    ) -> Tuple[bool, ContourCompatibilityReporter]:
+    ) -> tuple[bool, ContourCompatibilityReporter]:
         """Evaluate interpolation compatibility with another contour.
 
         :param other: The other :class:`BaseContour` instance to check
@@ -514,7 +513,7 @@ class BaseContour(
             [Fatal] Contour: [0] is closed | [0] is open
 
         """
-        return super(BaseContour, self).isCompatible(other, BaseContour)
+        return super().isCompatible(other, BaseContour)
 
     def _isCompatible(
         self, other: BaseContour, reporter: ContourCompatibilityReporter
@@ -794,13 +793,13 @@ class BaseContour(
         """,
     )
 
-    def _get_base_bounds(self) -> Optional[QuadrupleType[float]]:
+    def _get_base_bounds(self) -> QuadrupleType[float] | None:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> Optional[QuadrupleType[float]]:
+    def _get_bounds(self) -> QuadrupleType[float] | None:
         """Get the bounds of the contour.
 
         This is the environment implementation of the :attr:`BaseContour.bounds`
@@ -839,13 +838,13 @@ class BaseContour(
         """,
     )
 
-    def _get_base_area(self) -> Optional[float]:
+    def _get_base_area(self) -> float | None:
         value = self._get_area()
         if value is not None:
             value = normalizers.normalizeArea(value)
         return value
 
-    def _get_area(self) -> Optional[float]:
+    def _get_area(self) -> float | None:
         """Get the area of the native contour
 
         This is the environment implementation of the :attr:`BaseContour.area`
@@ -894,7 +893,7 @@ class BaseContour(
         """,
     )
 
-    def _get_segments(self) -> Tuple[BaseSegment, ...]:
+    def _get_segments(self) -> tuple[BaseSegment, ...]:
         """Get the native countour's segments.
 
         This is the environment implementation of the :attr:`BaseContour.segments`
@@ -910,7 +909,7 @@ class BaseContour(
         points = self.points
         if not points:
             return ()
-        segments: List[List[BasePoint]] = [[]]
+        segments: list[list[BasePoint]] = [[]]
         lastWasOffCurve = False
         firstIsMove = points[0].type == "move"
         for point in points:
@@ -932,7 +931,7 @@ class BaseContour(
             segment = segments.pop(0)
             segments.append(segment)
         # wrap into segments
-        wrapped: List[BaseSegment] = []
+        wrapped: list[BaseSegment] = []
         for points in segments:
             if self.segmentClass is None:
                 raise TypeError("segmentClass cannot be None.")
@@ -998,10 +997,10 @@ class BaseContour(
 
     def appendSegment(
         self,
-        type: Optional[str] = None,
-        points: Optional[PointCollectionType] = None,
+        type: str | None = None,
+        points: PointCollectionType | None = None,
         smooth: bool = False,
-        segment: Optional[BaseSegment] = None,
+        segment: BaseSegment | None = None,
     ) -> None:
         """Append the given segment to the contour.
 
@@ -1067,10 +1066,10 @@ class BaseContour(
     def insertSegment(
         self,
         index: int,
-        type: Optional[str] = None,
-        points: Optional[PointCollectionType] = None,
+        type: str | None = None,
+        points: PointCollectionType | None = None,
         smooth: bool = False,
-        segment: Optional[BaseSegment] = None,
+        segment: BaseSegment | None = None,
     ) -> None:
         """Insert the given segment into the contour.
 
@@ -1155,7 +1154,7 @@ class BaseContour(
             self.insertPoint(ptCount, offCurvePoint, type="offcurve")
 
     def removeSegment(
-        self, segment: Union[BaseSegment, int], preserveCurve: bool = False
+        self, segment: BaseSegment | int, preserveCurve: bool = False
     ) -> None:
         """Remove the given segment from the contour.
 
@@ -1209,7 +1208,7 @@ class BaseContour(
         for point in segment.points:
             self.removePoint(point, preserveCurve)
 
-    def setStartSegment(self, segment: Union[BaseSegment, int]) -> None:
+    def setStartSegment(self, segment: BaseSegment | int) -> None:
         """Set the first segment in the contour.
 
         :param segment: The segment to set as the first instance in the contour
@@ -1238,7 +1237,7 @@ class BaseContour(
             return
         if segmentIndex >= len(segments):
             raise ValueError(
-                (f"The contour does not contain a segment at index {segmentIndex}")
+                f"The contour does not contain a segment at index {segmentIndex}"
             )
         self._setStartSegment(segmentIndex)
 
@@ -1280,8 +1279,8 @@ class BaseContour(
         """,
     )
 
-    def _get_bPoints(self) -> Tuple[BaseBPoint, ...]:
-        bPoints: List[BaseBPoint] = []
+    def _get_bPoints(self) -> tuple[BaseBPoint, ...]:
+        bPoints: list[BaseBPoint] = []
         for point in self.points:
             if point.type not in ("move", "line", "curve"):
                 continue
@@ -1295,11 +1294,11 @@ class BaseContour(
 
     def appendBPoint(
         self,
-        type: Optional[str] = None,
-        anchor: Optional[PairCollectionType[IntFloatType]] = None,
-        bcpIn: Optional[PairCollectionType[IntFloatType]] = None,
-        bcpOut: Optional[PairCollectionType[IntFloatType]] = None,
-        bPoint: Optional[BaseBPoint] = None,
+        type: str | None = None,
+        anchor: PairCollectionType[IntFloatType] | None = None,
+        bcpIn: PairCollectionType[IntFloatType] | None = None,
+        bcpOut: PairCollectionType[IntFloatType] | None = None,
+        bPoint: BaseBPoint | None = None,
     ) -> None:
         """Append the given bPoint to the contour.
 
@@ -1377,11 +1376,11 @@ class BaseContour(
     def insertBPoint(
         self,
         index: int,
-        type: Optional[str] = None,
-        anchor: Optional[PairCollectionType[IntFloatType]] = None,
-        bcpIn: Optional[PairCollectionType[IntFloatType]] = None,
-        bcpOut: Optional[PairCollectionType[IntFloatType]] = None,
-        bPoint: Optional[BaseBPoint] = None,
+        type: str | None = None,
+        anchor: PairCollectionType[IntFloatType] | None = None,
+        bcpIn: PairCollectionType[IntFloatType] | None = None,
+        bcpOut: PairCollectionType[IntFloatType] | None = None,
+        bPoint: BaseBPoint | None = None,
     ) -> None:
         """Insert the given bPoint into the contour.
 
@@ -1480,7 +1479,7 @@ class BaseContour(
         bPoint.bcpOut = bcpOut
         bPoint.type = type
 
-    def removeBPoint(self, bPoint: Union[BaseBPoint, int]) -> None:
+    def removeBPoint(self, bPoint: BaseBPoint | int) -> None:
         """Remove the given bPoint from the contour.
 
         :param bPoint: The bPoint to remove as a :class:`BaseBPoint` instance,
@@ -1553,7 +1552,7 @@ class BaseContour(
         """,
     )
 
-    def _get_points(self) -> Tuple[BasePoint, ...]:
+    def _get_points(self) -> tuple[BasePoint, ...]:
         """Get a list of all points in the native contour.
 
         This is the environment implementation of the :attr:`BaseContour.points`
@@ -1617,12 +1616,12 @@ class BaseContour(
 
     def appendPoint(
         self,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
+        position: PairCollectionType[IntFloatType] | None = None,
         type: str = "line",
         smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        point: Optional[BasePoint] = None,
+        name: str | None = None,
+        identifier: str | None = None,
+        point: BasePoint | None = None,
     ) -> None:
         """Append the given point to the contour.
 
@@ -1665,12 +1664,12 @@ class BaseContour(
     def insertPoint(
         self,
         index: int,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
+        position: PairCollectionType[IntFloatType] | None = None,
         type: str = "line",
         smooth: bool = False,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
-        point: Optional[BasePoint] = None,
+        name: str | None = None,
+        identifier: str | None = None,
+        point: BasePoint | None = None,
     ) -> None:
         """Insert the given point into the contour.
 
@@ -1730,8 +1729,8 @@ class BaseContour(
         position: PairCollectionType[IntFloatType],
         type: str,
         smooth: bool,
-        name: Optional[str],
-        identifier: Optional[str],
+        name: str | None,
+        identifier: str | None,
         **kwargs: Any,
     ) -> None:
         r"""Insert the given point into the native contour.
@@ -1769,7 +1768,7 @@ class BaseContour(
         self.raiseNotImplementedError()
 
     def removePoint(
-        self, point: Union[BasePoint, int], preserveCurve: bool = False
+        self, point: BasePoint | int, preserveCurve: bool = False
     ) -> None:
         """Remove the given point from the contour.
 
@@ -1822,7 +1821,7 @@ class BaseContour(
         """
         self.raiseNotImplementedError()
 
-    def setStartPoint(self, point: Union[BasePoint, int]) -> None:
+    def setStartPoint(self, point: BasePoint | int) -> None:
         """Set the first segment in the contour.
 
         :param segment: The point to set as the first instance in the contour
@@ -1849,7 +1848,7 @@ class BaseContour(
             return
         if pointIndex >= len(points):
             raise ValueError(
-                (f"The contour does not contain a point at index {pointIndex}")
+                f"The contour does not contain a point at index {pointIndex}"
             )
         self._setStartPoint(pointIndex)
 
@@ -1915,14 +1914,14 @@ class BaseContour(
         """,
     )
 
-    def _get_base_selectedSegments(self) -> Tuple[BaseSegment, ...]:
+    def _get_base_selectedSegments(self) -> tuple[BaseSegment, ...]:
         selected = tuple(
             normalizers.normalizeSegment(segment)
             for segment in self._get_selectedSegments()
         )
         return selected
 
-    def _get_selectedSegments(self) -> Tuple[BaseSegment, ...]:
+    def _get_selectedSegments(self) -> tuple[BaseSegment, ...]:
         """Get the selected segments in the native contour.
 
         This is the environment implementation of the
@@ -1940,11 +1939,11 @@ class BaseContour(
         return self._getSelectedSubObjects(self.segments)
 
     def _set_base_selectedSegments(
-        self, value: CollectionType[Union[BaseSegment, int]]
+        self, value: CollectionType[BaseSegment | int]
     ) -> None:
         normalized = []
         for segment in value:
-            normalizedSegment: Union[BaseSegment, int]
+            normalizedSegment: BaseSegment | int
             if isinstance(segment, int):
                 normalizedIndex = normalizers.normalizeIndex(segment)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -1957,7 +1956,7 @@ class BaseContour(
         self._set_selectedSegments(normalized)
 
     def _set_selectedSegments(
-        self, value: CollectionType[Union[BaseSegment, int]]
+        self, value: CollectionType[BaseSegment | int]
     ) -> None:
         """Set the selected segments in the native contour.
 
@@ -2006,13 +2005,13 @@ class BaseContour(
         """,
     )
 
-    def _get_base_selectedPoints(self) -> Tuple[BasePoint, ...]:
+    def _get_base_selectedPoints(self) -> tuple[BasePoint, ...]:
         selected = tuple(
             normalizers.normalizePoint(point) for point in self._get_selectedPoints()
         )
         return selected
 
-    def _get_selectedPoints(self) -> Tuple[BasePoint, ...]:
+    def _get_selectedPoints(self) -> tuple[BasePoint, ...]:
         """Get the selected points in the native contour.
 
         This is the environment implementation of
@@ -2030,11 +2029,11 @@ class BaseContour(
         return self._getSelectedSubObjects(self.points)
 
     def _set_base_selectedPoints(
-        self, value: CollectionType[Union[BasePoint, int]]
+        self, value: CollectionType[BasePoint | int]
     ) -> None:
         normalized = []
         for point in value:
-            normalizedPoint: Union[BasePoint, int]
+            normalizedPoint: BasePoint | int
             if isinstance(point, int):
                 normalizedIndex = normalizers.normalizeIndex(point)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -2046,7 +2045,7 @@ class BaseContour(
             normalized.append(normalizedPoint)
         self._set_selectedPoints(normalized)
 
-    def _set_selectedPoints(self, value: CollectionType[Union[BasePoint, int]]) -> None:
+    def _set_selectedPoints(self, value: CollectionType[BasePoint | int]) -> None:
         """Set the selected points in the native contour.
 
         This is the environment implementation of
@@ -2094,14 +2093,14 @@ class BaseContour(
         """,
     )
 
-    def _get_base_selectedBPoints(self) -> Tuple[BaseBPoint, ...]:
+    def _get_base_selectedBPoints(self) -> tuple[BaseBPoint, ...]:
         selected = tuple(
             normalizers.normalizeBPoint(bPoint)
             for bPoint in self._get_selectedBPoints()
         )
         return selected
 
-    def _get_selectedBPoints(self) -> Tuple[BaseBPoint, ...]:
+    def _get_selectedBPoints(self) -> tuple[BaseBPoint, ...]:
         """Get the selected bPoints in the native contour.
 
         This is the environment implementation of
@@ -2119,11 +2118,11 @@ class BaseContour(
         return self._getSelectedSubObjects(self.bPoints)
 
     def _set_base_selectedBPoints(
-        self, value: CollectionType[Union[BaseBPoint, int]]
+        self, value: CollectionType[BaseBPoint | int]
     ) -> None:
         normalized = []
         for bPoint in value:
-            normalizedBPoint: Union[BaseBPoint, int]
+            normalizedBPoint: BaseBPoint | int
             if isinstance(bPoint, int):
                 normalizedIndex = normalizers.normalizeIndex(bPoint)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -2136,7 +2135,7 @@ class BaseContour(
         self._set_selectedBPoints(normalized)
 
     def _set_selectedBPoints(
-        self, value: CollectionType[Union[BaseBPoint, int]]
+        self, value: CollectionType[BaseBPoint | int]
     ) -> None:
         """Set the selected bPoints in the native contour.
 

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -1,15 +1,5 @@
 from __future__ import annotations
-from typing import (
-    TYPE_CHECKING,
-    cast,
-    Any,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, cast, Any, List, Optional, Tuple, Type, TypeVar, Union
 from collections.abc import Callable, Iterator
 
 from fontParts.base.errors import FontPartsError
@@ -131,9 +121,7 @@ class BaseContour(
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for contour already set")
         if glyph is not None:
@@ -1767,9 +1755,7 @@ class BaseContour(
         """
         self.raiseNotImplementedError()
 
-    def removePoint(
-        self, point: BasePoint | int, preserveCurve: bool = False
-    ) -> None:
+    def removePoint(self, point: BasePoint | int, preserveCurve: bool = False) -> None:
         """Remove the given point from the contour.
 
         If ``preserveCurve=True``, an attempt will be made to preserve the
@@ -1955,9 +1941,7 @@ class BaseContour(
             normalized.append(normalizedSegment)
         self._set_selectedSegments(normalized)
 
-    def _set_selectedSegments(
-        self, value: CollectionType[BaseSegment | int]
-    ) -> None:
+    def _set_selectedSegments(self, value: CollectionType[BaseSegment | int]) -> None:
         """Set the selected segments in the native contour.
 
         This is the environment implementation of the
@@ -2028,9 +2012,7 @@ class BaseContour(
         """
         return self._getSelectedSubObjects(self.points)
 
-    def _set_base_selectedPoints(
-        self, value: CollectionType[BasePoint | int]
-    ) -> None:
+    def _set_base_selectedPoints(self, value: CollectionType[BasePoint | int]) -> None:
         normalized = []
         for point in value:
             normalizedPoint: BasePoint | int
@@ -2134,9 +2116,7 @@ class BaseContour(
             normalized.append(normalizedBPoint)
         self._set_selectedBPoints(normalized)
 
-    def _set_selectedBPoints(
-        self, value: CollectionType[BaseBPoint | int]
-    ) -> None:
+    def _set_selectedBPoints(self, value: CollectionType[BaseBPoint | int]) -> None:
         """Set the selected bPoints in the native contour.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/deprecated.py
+++ b/Lib/fontParts/base/deprecated.py
@@ -13,13 +13,13 @@ class RemovedError(Exception):
 # ========
 
 
-class RemovedBase(object):
+class RemovedBase:
     def setParent(self, parent):
         objName = self.__class__.__name__.replace("Removed", "")
         raise RemovedError(f"'{objName}.setParent()'")
 
 
-class DeprecatedBase(object):
+class DeprecatedBase:
     def update(self):
         objName = self.__class__.__name__.replace("Deprecated", "")
         warnings.warn(
@@ -40,7 +40,7 @@ class DeprecatedBase(object):
 # ==================
 
 
-class DeprecatedTransformation(object):
+class DeprecatedTransformation:
     def move(self, *args, **kwargs):
         objName = self.__class__.__name__.replace("Deprecated", "")
         warnings.warn(f"'{objName}.move()': use {objName}.moveBy()", DeprecationWarning)
@@ -164,7 +164,7 @@ class RemovedAnchor(RemovedBase):
     @staticmethod
     def drawPoints(pen):
         raise RemovedError(
-            ("'Anchor.drawPoints': UFO3 is not drawing anchors into point pens")
+            "'Anchor.drawPoints': UFO3 is not drawing anchors into point pens"
         )
 
 
@@ -450,7 +450,7 @@ class RemovedLib(RemovedBase):
     pass
 
 
-class DeprecatedLib(object):
+class DeprecatedLib:
     def getParent(self):
         warnings.warn(
             "'Lib.getParent()': use 'Lib.glyph' or 'Lib.font'", DeprecationWarning
@@ -474,7 +474,7 @@ class RemovedGroups(RemovedBase):
     pass
 
 
-class DeprecatedGroups(object):
+class DeprecatedGroups:
     def getParent(self):
         warnings.warn("'Groups.getParent()': use 'Groups.font'", DeprecationWarning)
         return self.font
@@ -489,7 +489,7 @@ class DeprecatedGroups(object):
 # ===========
 
 
-class RemovedKerning(object):
+class RemovedKerning:
     @staticmethod
     def setParent(parent):
         raise RemovedError("'Kerning.setParent()'")
@@ -549,7 +549,7 @@ class RemovedKerning(object):
         raise RemovedError("Kerning.explodeClasses()")
 
 
-class DeprecatedKerning(object):
+class DeprecatedKerning:
     def setChanged(self):
         warnings.warn("'Kerning.setChanged': use Kerning.changed()", DeprecationWarning)
         self.changed()

--- a/Lib/fontParts/base/features.py
+++ b/Lib/fontParts/base/features.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Callable, Tuple, List, Optional, Union
+from typing import TYPE_CHECKING, Tuple, List, Optional, Union
+from collections.abc import Callable
 
 from fontParts.base.base import BaseObject, dynamicProperty, reference
 from fontParts.base import normalizers
@@ -17,9 +18,9 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
 
     """
 
-    copyAttributes: Tuple[str] = ("text",)
+    copyAttributes: tuple[str] = ("text",)
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.font is not None:
             contents.append("for font")
@@ -32,7 +33,7 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -53,13 +54,13 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is None:
             return None
         return self._font()
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError(
@@ -86,18 +87,18 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
         """,
     )
 
-    def _get_base_text(self) -> Optional[str]:
+    def _get_base_text(self) -> str | None:
         value = self._get_text()
         if value is not None:
             value = normalizers.normalizeFeatureText(value)
         return value
 
-    def _set_base_text(self, value: Optional[str]) -> None:
+    def _set_base_text(self, value: str | None) -> None:
         if value is not None:
             value = normalizers.normalizeFeatureText(value)
         self._set_text(value)
 
-    def _get_text(self) -> Optional[str]:
+    def _get_text(self) -> str | None:
         """Get the features text.
 
         This is the environment implementation of the :attr:`BaseFeatures.text` property
@@ -115,7 +116,7 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
         """
         self.raiseNotImplementedError()
 
-    def _set_text(self, value: Optional[str]) -> None:
+    def _set_text(self, value: str | None) -> None:
         """Set the features text.
 
         Description

--- a/Lib/fontParts/base/features.py
+++ b/Lib/fontParts/base/features.py
@@ -59,9 +59,7 @@ class BaseFeatures(BaseObject, DeprecatedFeatures, RemovedFeatures):
             return None
         return self._font()
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError(
                 "font for features already set and is not same as font"

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -79,7 +79,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     )
 
     def copy(self) -> BaseFont:
-        """Copy data from the the current font into a new font.
+        """Copy data from the current font into a new font.
 
         This will copy:
 
@@ -1092,7 +1092,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
         :param name: The name of the :class:`BaseLayer` instance to
             retrieve.
-        :return: The specified :class:`Baselayer` instance.
+        :return: The specified :class:`BaseLayer` instance.
         :raises ValueError: If no layer with the given `name` exists in
             the font.
 
@@ -1466,7 +1466,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             with :func:`normalizers.normalizeGlyphName` and verified as
             unique within the default layer.
         :param \**kwargs: Additional keyword arguments.
-        :return: An instance of a :class:`BaseGlyph subclass representing
+        :return: An instance of a :class:`BaseGlyph` subclass representing
             the new glyph.
 
         .. note::
@@ -1991,7 +1991,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         This is the environment implementation of :meth:`BaseFont.interpolate`.
 
         :param factor: The interpolation value as a single :class:`int`
-            or :class:`float` or a :class:`tuple of two :class:`int`
+            or :class:`float` or a :class:`tuple` of two :class:`int`
             or :class:`float` values representing the factors ``(x, y)``.
         :param minFont: The :class:`BaseFont` subclass instance
             corresponding to the 0.0 position in the interpolation.

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -53,13 +53,9 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     """
 
     def __init__(
-        self,
-        pathOrObject: str | BaseFont | None = None,
-        showInterface: bool = True,
+        self, pathOrObject: str | BaseFont | None = None, showInterface: bool = True
     ) -> None:
-        super().__init__(
-            pathOrObject=pathOrObject, showInterface=showInterface
-        )
+        super().__init__(pathOrObject=pathOrObject, showInterface=showInterface)
 
     def _reprContents(self) -> list[str]:
         contents: list[str] = [f"'{self.info.familyName} {self.info.styleName}'"]
@@ -142,10 +138,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     # Initialize
 
     def _init(
-        self,
-        pathOrObject: str | BaseFont | None,
-        showInterface: bool,
-        **kwargs: Any,
+        self, pathOrObject: str | BaseFont | None, showInterface: bool, **kwargs: Any
     ) -> None:
         r"""Initialize the native font object.
 
@@ -474,8 +467,8 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         elif os.path.isdir(path):
             if self.path is None:
                 raise OSError(
-                        "The file cannot be generated because "
-                        "the file does not have a path."
+                    "The file cannot be generated because "
+                    "the file does not have a path."
                 )
             fileName = os.path.basename(self.path)
             fileName += ext
@@ -506,11 +499,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return False
 
     def _generate(
-        self,
-        format: str,
-        path: str | None,
-        environmentOptions: dict,
-        **kwargs: object,
+        self, format: str, path: str | None, environmentOptions: dict, **kwargs: object
     ) -> None:
         """Generate the native font in another format.
 
@@ -2411,9 +2400,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         return self._getSelectedSubObjects(self.guidelines)
 
-    def _set_base_selectedGuidelines(
-        self, value: list[BaseGuideline | int]
-    ) -> None:
+    def _set_base_selectedGuidelines(self, value: list[BaseGuideline | int]) -> None:
         normalized = []
         for guideline in value:
             normalizedGuideline: BaseGuideline | int

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -54,15 +54,15 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def __init__(
         self,
-        pathOrObject: Optional[Union[str, "BaseFont"]] = None,
+        pathOrObject: str | BaseFont | None = None,
         showInterface: bool = True,
     ) -> None:
-        super(BaseFont, self).__init__(
+        super().__init__(
             pathOrObject=pathOrObject, showInterface=showInterface
         )
 
-    def _reprContents(self) -> List[str]:
-        contents: List[str] = [f"'{self.info.familyName} {self.info.styleName}'"]
+    def _reprContents(self) -> list[str]:
+        contents: list[str] = [f"'{self.info.familyName} {self.info.styleName}'"]
         if self.path is not None:
             contents.append(f"path={self.path!r}")
         return contents
@@ -71,7 +71,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     # Copy
     # ----
 
-    copyAttributes: Tuple[str, ...] = (
+    copyAttributes: tuple[str, ...] = (
         "info",
         "groups",
         "kerning",
@@ -106,7 +106,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             >>> copiedFont = font.copy()
 
         """
-        return super(BaseFont, self).copy()
+        return super().copy()
 
     def copyData(self, source: BaseFont) -> None:
         """Copy data from another font instance.
@@ -133,7 +133,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             layer.copyData(source.getLayer(layerName))
         for guideline in source.guidelines:
             self.appendGuideline(guideline=guideline)
-        super(BaseFont, self).copyData(source)
+        super().copyData(source)
 
     # ---------------
     # File Operations
@@ -143,7 +143,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def _init(
         self,
-        pathOrObject: Optional[Union[str, BaseFont]],
+        pathOrObject: str | BaseFont | None,
         showInterface: bool,
         **kwargs: Any,
     ) -> None:
@@ -196,13 +196,13 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_path(self) -> Optional[str]:
-        path: Optional[str] = self._get_path()
+    def _get_base_path(self) -> str | None:
+        path: str | None = self._get_path()
         if path is not None:
             path = normalizers.normalizeFilePath(path)
         return path
 
-    def _get_path(self, **kwargs: Any) -> Optional[str]:  # type: ignore[return]
+    def _get_path(self, **kwargs: Any) -> str | None:  # type: ignore[return]
         r"""Get the path to the native font file.
 
         This method is the environment implementation
@@ -227,10 +227,10 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def save(
         self,
-        path: Optional[str] = None,
+        path: str | None = None,
         showProgress: bool = False,
-        formatVersion: Optional[int] = None,
-        fileStructure: Optional[str] = None,
+        formatVersion: int | None = None,
+        fileStructure: str | None = None,
     ) -> None:
         """Save the font to the specified path.
 
@@ -272,8 +272,8 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
         """
         if path is None and self.path is None:
-            raise IOError(
-                ("The font cannot be saved because no file location has been given.")
+            raise OSError(
+                "The font cannot be saved because no file location has been given."
             )
         if path is not None:
             path = normalizers.normalizeFilePath(path)
@@ -291,10 +291,10 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def _save(
         self,
-        path: Optional[str],
+        path: str | None,
         showProgress: bool,
-        formatVersion: Optional[int],
-        fileStructure: Optional[str],
+        formatVersion: int | None,
+        fileStructure: str | None,
         **kwargs: Any,
     ) -> None:
         r"""Save the native font to the specified path.
@@ -411,7 +411,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return formatToExtension.get(format, fallbackFormat)
 
     def generate(
-        self, format: str, path: Optional[str] = None, **environmentOptions: Any
+        self, format: str, path: str | None = None, **environmentOptions: Any
     ) -> None:
         r"""Generate the font in another format.
 
@@ -465,19 +465,17 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         environmentOptions = env
         ext = self.generateFormatToExtension(format, "." + format)
         if path is None and self.path is None:
-            raise IOError(
-                ("The file cannot be generated because an output path was not defined.")
+            raise OSError(
+                "The file cannot be generated because an output path was not defined."
             )
         elif path is None:
             path = os.path.splitext(self.path)[0]
             path += ext
         elif os.path.isdir(path):
             if self.path is None:
-                raise IOError(
-                    (
+                raise OSError(
                         "The file cannot be generated because "
                         "the file does not have a path."
-                    )
                 )
             fileName = os.path.basename(self.path)
             fileName += ext
@@ -510,7 +508,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     def _generate(
         self,
         format: str,
-        path: Optional[str],
+        path: str | None,
         environmentOptions: dict,
         **kwargs: object,
     ) -> None:
@@ -872,13 +870,13 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_layers(self) -> Tuple[BaseLayer, ...]:
-        layers: Tuple[BaseLayer, ...] = self._get_layers()
+    def _get_base_layers(self) -> tuple[BaseLayer, ...]:
+        layers: tuple[BaseLayer, ...] = self._get_layers()
         for layer in layers:
             self._setFontInLayer(layer)
         return tuple(layers)
 
-    def _get_layers(self, **kwargs: Any) -> Tuple[BaseLayer, ...]:  # type: ignore[return]
+    def _get_layers(self, **kwargs: Any) -> tuple[BaseLayer, ...]:  # type: ignore[return]
         r"""Get the native font's layer objects.
 
         This is the environment implementation of
@@ -918,7 +916,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_layerOrder(self) -> Tuple[str, ...]:
+    def _get_base_layerOrder(self) -> tuple[str, ...]:
         value: CollectionType[str] = self._get_layerOrder()
         value = normalizers.normalizeLayerOrder(value, self)
         return value
@@ -927,7 +925,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         value = normalizers.normalizeLayerOrder(value, self)
         self._set_layerOrder(value)
 
-    def _get_layerOrder(self, **kwargs: Any) -> Tuple[str, ...]:  # type: ignore[return]
+    def _get_layerOrder(self, **kwargs: Any) -> tuple[str, ...]:  # type: ignore[return]
         r"""Get the order of the layers in the native font.
 
         This is the environment implementation of the
@@ -1150,7 +1148,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     # new
 
     def newLayer(
-        self, name: str, color: Optional[QuadrupleCollectionType[IntFloatType]] = None
+        self, name: str, color: QuadrupleCollectionType[IntFloatType] | None = None
     ) -> BaseLayer:
         """Create a new layer in the font.
 
@@ -1179,7 +1177,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     def _newLayer(  # type: ignore[return]
         self,
         name: str,
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
+        color: QuadrupleCollectionType[IntFloatType] | None,
         **kwargs: Any,
     ) -> BaseLayer:
         r"""Create a new layer in the native font.
@@ -1245,7 +1243,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     # insert
 
-    def insertLayer(self, layer: BaseLayer, name: Optional[str] = None) -> BaseLayer:
+    def insertLayer(self, layer: BaseLayer, name: str | None = None) -> BaseLayer:
         """Insert a specified layer into the font.
 
         This method will not insert a layer directly, but rather create
@@ -1453,7 +1451,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         layer = self.defaultLayer
         return layer[name]
 
-    def _keys(self, **kwargs: Any) -> Tuple[str, ...]:
+    def _keys(self, **kwargs: Any) -> tuple[str, ...]:
         r"""Get a list of all glyph names in the native default layer.
 
         This is the environment implementation of :meth:`BaseFont.keys`.
@@ -1563,7 +1561,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_glyphOrder(self) -> Tuple[str, ...]:
+    def _get_base_glyphOrder(self) -> tuple[str, ...]:
         value = self._get_glyphOrder()
         value = normalizers.normalizeGlyphOrder(value)
         return value
@@ -1572,7 +1570,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         value = normalizers.normalizeGlyphOrder(value)
         self._set_glyphOrder(value)
 
-    def _get_glyphOrder(self) -> Tuple[str, ...]:  # type: ignore[return]
+    def _get_glyphOrder(self) -> tuple[str, ...]:  # type: ignore[return]
         r"""Get the order of the glyphs in the native font.
 
         This is the environment implementation of the
@@ -1706,7 +1704,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_guidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_guidelines(self) -> tuple[BaseGuideline, ...]:
         """Get the native font-level guideline objects.
 
         This is the environment implementation of
@@ -1774,11 +1772,11 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def appendGuideline(
         self,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
-        angle: Optional[IntFloatType] = None,
-        name: Optional[str] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        guideline: Optional[BaseGuideline] = None,
+        position: PairCollectionType[IntFloatType] | None = None,
+        angle: IntFloatType | None = None,
+        name: str | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        guideline: BaseGuideline | None = None,
     ) -> BaseGuideline:
         """Append a new guideline to the font.
 
@@ -1821,9 +1819,9 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             if color is None:
                 color = normalizedGuideline.color
             if normalizedGuideline.identifier is not None:
-                existing = set(
-                    [g.identifier for g in self.guidelines if g.identifier is not None]
-                )
+                existing = {
+                    g.identifier for g in self.guidelines if g.identifier is not None
+                }
                 if normalizedGuideline.identifier not in existing:
                     identifier = normalizedGuideline.identifier
         if position is not None:
@@ -1846,9 +1844,9 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     def _appendGuideline(  # type: ignore[return]
         self,
         position: PairCollectionType[IntFloatType],
-        angle: Optional[float],
-        name: Optional[str],
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
+        angle: float | None,
+        name: str | None,
+        color: QuadrupleCollectionType[IntFloatType] | None,
         **kwargs: Any,
     ) -> BaseGuideline:
         r"""Append a new guideline to the native font.
@@ -1872,7 +1870,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         self.raiseNotImplementedError()
 
-    def removeGuideline(self, guideline: Union[int, BaseGuideline]) -> None:
+    def removeGuideline(self, guideline: int | BaseGuideline) -> None:
         """Remove a guideline from the font.
 
         :param guideline: A :class:`BaseGuideline` object or an integer
@@ -2057,7 +2055,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def isCompatible(
         self, other: BaseFont, cls=None
-    ) -> Tuple[bool, FontCompatibilityReporter]:
+    ) -> tuple[bool, FontCompatibilityReporter]:
         """Evaluate interpolation compatibility with another font.
 
         This method will return a :class:`bool` indicating if the font is
@@ -2080,7 +2078,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             [Fatal] Glyph: "test1" contains 1 contours | "test2" contains 2 contours
 
         """
-        return super(BaseFont, self).isCompatible(other, BaseFont)
+        return super().isCompatible(other, BaseFont)
 
     def _isCompatible(
         self, other: BaseFont, reporter: FontCompatibilityReporter
@@ -2251,13 +2249,13 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_selectedLayers(self) -> Tuple[BaseLayer, ...]:
+    def _get_base_selectedLayers(self) -> tuple[BaseLayer, ...]:
         selected = tuple(
             normalizers.normalizeLayer(layer) for layer in self._get_selectedLayers()
         )
         return selected
 
-    def _get_selectedLayers(self) -> Tuple[BaseLayer, ...]:
+    def _get_selectedLayers(self) -> tuple[BaseLayer, ...]:
         """Get the selected glyph layers in the native default font layer.
 
         This is the environment implementation of
@@ -2274,11 +2272,11 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         return self._getSelectedSubObjects(self.layers)
 
-    def _set_base_selectedLayers(self, value: List[BaseLayer]) -> None:
+    def _set_base_selectedLayers(self, value: list[BaseLayer]) -> None:
         normalized = [normalizers.normalizeLayer(layer) for layer in value]
         self._set_selectedLayers(normalized)
 
-    def _set_selectedLayers(self, value: List[BaseLayer]) -> None:
+    def _set_selectedLayers(self, value: list[BaseLayer]) -> None:
         """Set the selected glyph layers in the native default font layer.
 
         This is the environment implementation of
@@ -2316,14 +2314,14 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_selectedLayerNames(self) -> Tuple[str, ...]:
+    def _get_base_selectedLayerNames(self) -> tuple[str, ...]:
         selected = tuple(
             normalizers.normalizeLayerName(name)
             for name in self._get_selectedLayerNames()
         )
         return selected
 
-    def _get_selectedLayerNames(self) -> Tuple[str, ...]:
+    def _get_selectedLayerNames(self) -> tuple[str, ...]:
         """Get the selected glyph layer names in the native font layer.
 
         This is the environment implementation of
@@ -2340,11 +2338,11 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """
         return tuple(layer.name for layer in self.selectedLayers)
 
-    def _set_base_selectedLayerNames(self, value: List[str]) -> None:
+    def _set_base_selectedLayerNames(self, value: list[str]) -> None:
         normalized = [normalizers.normalizeLayerName(name) for name in value]
         self._set_selectedLayerNames(normalized)
 
-    def _set_selectedLayerNames(self, value: List[str]) -> None:
+    def _set_selectedLayerNames(self, value: list[str]) -> None:
         """Set the selected glyph layer names in the native font layer.
 
         This is the environment implementation of
@@ -2389,14 +2387,14 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         """,
     )
 
-    def _get_base_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_base_selectedGuidelines(self) -> tuple[BaseGuideline, ...]:
         selected = tuple(
             normalizers.normalizeGuideline(guideline)
             for guideline in self._get_selectedGuidelines()
         )
         return selected
 
-    def _get_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_selectedGuidelines(self) -> tuple[BaseGuideline, ...]:
         """Get the selected guidelines in the native font.
 
         This is the environment implementation of
@@ -2414,11 +2412,11 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return self._getSelectedSubObjects(self.guidelines)
 
     def _set_base_selectedGuidelines(
-        self, value: List[Union[BaseGuideline, int]]
+        self, value: list[BaseGuideline | int]
     ) -> None:
         normalized = []
         for guideline in value:
-            normalizedGuideline: Union[BaseGuideline, int]
+            normalizedGuideline: BaseGuideline | int
             if isinstance(guideline, int):
                 normalizedIndex = normalizers.normalizeIndex(guideline)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -2431,7 +2429,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
             normalized.append(normalizedGuideline)
         self._set_selectedGuidelines(normalized)
 
-    def _set_selectedGuidelines(self, value: List[Union[BaseGuideline, int]]) -> None:
+    def _set_selectedGuidelines(self, value: list[BaseGuideline | int]) -> None:
         """Set the selected guidelines in the native font.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1044,9 +1044,7 @@ class BaseGlyph(
             self.clearImage()
 
     def appendGlyph(
-        self,
-        other: BaseGlyph,
-        offset: PairCollectionType[IntFloatType] | None = None,
+        self, other: BaseGlyph, offset: PairCollectionType[IntFloatType] | None = None
     ) -> None:
         """Append data from `other` to new objects in the glyph.
 
@@ -3766,9 +3764,7 @@ class BaseGlyph(
             normalized.append(normalizedContour)
         self._set_selectedContours(normalized)
 
-    def _set_selectedContours(
-        self, value: CollectionType[BaseContour | int]
-    ) -> None:
+    def _set_selectedContours(self, value: CollectionType[BaseContour | int]) -> None:
         """Set the selected contours in the glyph.
 
         This is the environment implementation of
@@ -3940,9 +3936,7 @@ class BaseGlyph(
             normalized.append(normalizedAnchor)
         self._set_selectedAnchors(normalized)
 
-    def _set_selectedAnchors(
-        self, value: CollectionType[BaseAnchor | int]
-    ) -> None:
+    def _set_selectedAnchors(self, value: CollectionType[BaseAnchor | int]) -> None:
         """Set the selected anchors in the glyph.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1683,7 +1683,7 @@ class BaseGlyph(
 
         This property is read-only.
 
-        :return: A :class:`tuple` of :class:`BaseAnthor` instances.
+        :return: A :class:`tuple` of :class:`BaseAnchor` instances.
 
         Example::
 
@@ -1695,7 +1695,7 @@ class BaseGlyph(
     def _get_anchors(self) -> tuple[BaseAnchor, ...]:
         """Get all anchors in the native glyph.
 
-        :return: A :class:`tuple` of :class:`BaseAnthor` subclass instances.
+        :return: A :class:`tuple` of :class:`BaseAnchor` subclass instances.
 
         .. note::
 
@@ -2277,7 +2277,7 @@ class BaseGlyph(
           or height in the glyph divided by two)
         - the (negative) surface of the bounding box of the contour: ``width * height``
 
-        The latter is a safety net for for instances like a very thin 'O' where the
+        The latter is a safety net for instances like a very thin 'O' where the
         x centers could be close enough to rely on the y for the sort, which could
         very well be the same for both contours. We use the *negative* of the surface
         to ensure that larger contours appear first, which seems more natural.
@@ -2648,7 +2648,7 @@ class BaseGlyph(
     def __add__(self, other: BaseGlyph) -> BaseGlyph:
         """Add another glyph to the current glyph.
 
-        :param other: The :class:`BaseGLyph` instance to add to the current glyph.
+        :param other: The :class:`BaseGlyph` instance to add to the current glyph.
         :return: A new :class:`BaseGlyph` instance representing the added results.
 
         .. note::
@@ -2667,7 +2667,7 @@ class BaseGlyph(
     def __sub__(self, other: BaseGlyph) -> BaseGlyph:
         """Subtract another glyph from the current glyph.
 
-        :param other: The :class:`BaseGLyph` instance to subtract
+        :param other: The :class:`BaseGlyph` instance to subtract
             from the current glyph.
         :return: A new :class:`BaseGlyph` instance representing
             the subtracted results.
@@ -3054,8 +3054,8 @@ class BaseGlyph(
         This is the environment implementation of the :attr:`BaseGlyph.area`
         property getter.
 
-        :return: An :class:`int` or a :class:` float value representing the
-             area of the glyph, or or :obj:`None` if the glyph is empty.
+        :return: An :class:`int` or a :class:`float` value representing the
+             area of the glyph, or :obj:`None` if the glyph is empty.
 
         .. note::
 
@@ -3110,7 +3110,7 @@ class BaseGlyph(
 
         :param name: The name of the :class:`BaseLayer` instance to
             retrieve.
-        :return: The specified :class:`Baselayer` instance.
+        :return: The specified :class:`BaseLayer` instance.
         :raises ValueError: If no layer with the given `name` exists in
             the font.
 
@@ -3128,7 +3128,7 @@ class BaseGlyph(
         :param name: The name of the :class:`BaseLayer` instance to
             retrieve.
         :param \**kwargs: Additional keyword arguments.
-        :return: The specified :class:`Baselayer` instance.
+        :return: The specified :class:`BaseLayer` instance.
         :raises ValueError: If no layer with the given `name` exists in
             the font.
 

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0103, C0302, C0114, W0613
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Iterator, Optional, Union, List, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, Union, List, Tuple, TypeVar
+from collections.abc import Iterator
 from itertools import zip_longest
 from collections import Counter
 import os
@@ -50,11 +51,11 @@ if TYPE_CHECKING:
     from fontParts.base.anchor import BaseAnchor
     from fontParts.base.image import BaseImage
 
-    TempContourListType = List[
-        Tuple[int, int, IntFloatType, IntFloatType, IntFloatType, BaseContour]
+    TempContourListType = list[
+        tuple[int, int, IntFloatType, IntFloatType, IntFloatType, BaseContour]
     ]
-    ContourListType = List[
-        Tuple[int, int, FuzzyNumber, FuzzyNumber, IntFloatType, BaseContour]
+    ContourListType = list[
+        tuple[int, int, FuzzyNumber, FuzzyNumber, IntFloatType, BaseContour]
     ]
 
 
@@ -73,7 +74,7 @@ class BaseGlyph(
 
     """
 
-    copyAttributes: Tuple[str, ...] = (
+    copyAttributes: tuple[str, ...] = (
         "name",
         "unicodes",
         "width",
@@ -83,8 +84,8 @@ class BaseGlyph(
         "lib",
     )
 
-    def _reprContents(self) -> List[str]:
-        contents: List[str] = [f"'{self.name}'"]
+    def _reprContents(self) -> list[str]:
+        contents: list[str] = [f"'{self.name}'"]
         if self.layer is not None:
             contents.append(f"('{self.layer.name}')")
         return contents
@@ -116,7 +117,7 @@ class BaseGlyph(
             >>> copiedGlyph = glyph.copy()
 
         """
-        return super(BaseGlyph, self).copy()
+        return super().copy()
 
     def copyData(self: BaseGlyph, source: BaseGlyph) -> None:
         """Copy data from another glyph instance.
@@ -132,7 +133,7 @@ class BaseGlyph(
             >>> glyph.copyData(sourceGlyph)
 
         """
-        super(BaseGlyph, self).copyData(source)
+        super().copyData(source)
         for contour in source.contours:
             self.appendContour(contour)
         for component in source.components:
@@ -153,7 +154,7 @@ class BaseGlyph(
 
     # Layer
 
-    _layer: Optional[BaseLayer] = None
+    _layer: BaseLayer | None = None
 
     layer: dynamicProperty = dynamicProperty(
         "layer",
@@ -171,12 +172,12 @@ class BaseGlyph(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._layer is None:
             return None
         return self._layer
 
-    def _set_layer(self, layer: Optional[BaseLayer]) -> None:
+    def _set_layer(self, layer: BaseLayer | None) -> None:
         self._layer = layer
 
     # Font
@@ -197,7 +198,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._layer is None:
             return None
         return self.layer.font
@@ -299,7 +300,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_unicodes(self) -> Tuple[int, ...]:
+    def _get_base_unicodes(self) -> tuple[int, ...]:
         value = self._get_unicodes()
         value = normalizers.normalizeGlyphUnicodes(value)
         return value
@@ -382,20 +383,20 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_unicode(self) -> Optional[int]:
+    def _get_base_unicode(self) -> int | None:
         value = self._get_unicode()
         if value is not None:
             value = normalizers.normalizeGlyphUnicode(value)
         return value
 
-    def _set_base_unicode(self, value: Optional[int]) -> None:
+    def _set_base_unicode(self, value: int | None) -> None:
         if value is not None:
             value = normalizers.normalizeGlyphUnicode(value)
             self._set_unicode(value)
         else:
             self._set_unicodes(())
 
-    def _get_unicode(self) -> Optional[int]:
+    def _get_unicode(self) -> int | None:
         """Get the primary Unicode value assigned to the native glyph.
 
         This is the environment implementation of
@@ -414,7 +415,7 @@ class BaseGlyph(
             return values[0]
         return None
 
-    def _set_unicode(self, value: Optional[int]) -> None:
+    def _set_unicode(self, value: int | None) -> None:
         """Assign the primary Unicode value to the native glyph.
 
         This is the environment implementation of
@@ -551,7 +552,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_leftMargin(self) -> Optional[IntFloatType]:
+    def _get_base_leftMargin(self) -> IntFloatType | None:
         value = self._get_leftMargin()
         value = normalizers.normalizeGlyphLeftMargin(value)
         return value
@@ -563,7 +564,7 @@ class BaseGlyph(
             raise TypeError("The value for leftMargin cannot be None.")
         self._set_leftMargin(normalizedValue)
 
-    def _get_leftMargin(self) -> Optional[IntFloatType]:
+    def _get_leftMargin(self) -> IntFloatType | None:
         """Get the native glyph's left margin.
 
         This is the environment implementation of
@@ -619,7 +620,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_rightMargin(self) -> Optional[IntFloatType]:
+    def _get_base_rightMargin(self) -> IntFloatType | None:
         value = self._get_rightMargin()
         value = normalizers.normalizeGlyphRightMargin(value)
         return value
@@ -631,7 +632,7 @@ class BaseGlyph(
             raise TypeError("The value for rightMargin cannot be None.")
         self._set_rightMargin(normalizedValue)
 
-    def _get_rightMargin(self) -> Optional[IntFloatType]:
+    def _get_rightMargin(self) -> IntFloatType | None:
         """Get the native glyph's right margin.
 
         This is the environment implementation of
@@ -752,7 +753,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_bottomMargin(self) -> Optional[IntFloatType]:
+    def _get_base_bottomMargin(self) -> IntFloatType | None:
         value = self._get_bottomMargin()
         value = normalizers.normalizeGlyphBottomMargin(value)
         return value
@@ -764,7 +765,7 @@ class BaseGlyph(
             raise TypeError("The value for bottomMargin cannot be None.")
         self._set_bottomMargin(normalizedValue)
 
-    def _get_bottomMargin(self) -> Optional[IntFloatType]:
+    def _get_bottomMargin(self) -> IntFloatType | None:
         """Get the native glyph's bottom margin.
 
         This is the environment implementation of
@@ -819,7 +820,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_topMargin(self) -> Optional[IntFloatType]:
+    def _get_base_topMargin(self) -> IntFloatType | None:
         value = self._get_topMargin()
         value = normalizers.normalizeGlyphTopMargin(value)
         return value
@@ -831,7 +832,7 @@ class BaseGlyph(
             raise TypeError("The value for topMargin cannot be None.")
         self._set_topMargin(normalizedValue)
 
-    def _get_topMargin(self) -> Optional[IntFloatType]:
+    def _get_topMargin(self) -> IntFloatType | None:
         """Get the native glyph's top margin.
 
         This is the environment implementation of
@@ -1045,7 +1046,7 @@ class BaseGlyph(
     def appendGlyph(
         self,
         other: BaseGlyph,
-        offset: Optional[PairCollectionType[IntFloatType]] = None,
+        offset: PairCollectionType[IntFloatType] | None = None,
     ) -> None:
         """Append data from `other` to new objects in the glyph.
 
@@ -1121,7 +1122,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_contours(self) -> Tuple[BaseContour, ...]:
+    def _get_contours(self) -> tuple[BaseContour, ...]:
         """Get all contours in the native glyph.
 
         This is the environment implementation of the :attr:`BaseGlyph.contours`
@@ -1239,7 +1240,7 @@ class BaseGlyph(
     def appendContour(
         self,
         contour: BaseContour,
-        offset: Optional[PairCollectionType[IntFloatType]] = None,
+        offset: PairCollectionType[IntFloatType] | None = None,
     ) -> BaseContour:
         """Append the given contour's data to the glyph.
 
@@ -1293,7 +1294,7 @@ class BaseGlyph(
             contour.drawPoints(pointPen)
         return self[-1]
 
-    def removeContour(self, contour: Union[BaseContour, int]) -> None:
+    def removeContour(self, contour: BaseContour | int) -> None:
         """Remove the given contour from the glyph.
 
         :param contour: The contour to remove as a :class:`BaseContour`
@@ -1410,7 +1411,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_components(self) -> Tuple[BaseComponent, ...]:
+    def _get_components(self) -> tuple[BaseComponent, ...]:
         """Get all components in the native glyph.
 
         This is the environment implementation of
@@ -1479,10 +1480,10 @@ class BaseGlyph(
 
     def appendComponent(
         self,
-        baseGlyph: Optional[str] = None,
-        offset: Optional[PairCollectionType[IntFloatType]] = None,
-        scale: Optional[TransformationType] = None,
-        component: Optional[BaseComponent] = None,
+        baseGlyph: str | None = None,
+        offset: PairCollectionType[IntFloatType] | None = None,
+        scale: TransformationType | None = None,
+        component: BaseComponent | None = None,
     ) -> BaseComponent:
         """Append a component to the glyph.
 
@@ -1528,9 +1529,9 @@ class BaseGlyph(
             if baseGlyph is None:
                 baseGlyph = normalizedComponent.baseGlyph
             if normalizedComponent.identifier is not None:
-                existing = set(
+                existing = {
                     c.identifier for c in self.components if c.identifier is not None
-                )
+                }
                 if normalizedComponent.identifier not in existing:
                     identifier = normalizedComponent.identifier
         if baseGlyph is not None:
@@ -1558,8 +1559,8 @@ class BaseGlyph(
     def _appendComponent(
         self,
         baseGlyph: str,
-        transformation: Optional[SextupleCollectionType[IntFloatType]],
-        identifier: Optional[str],
+        transformation: SextupleCollectionType[IntFloatType] | None,
+        identifier: str | None,
         **kwargs: Any,
     ) -> BaseComponent:
         r"""Append a component to the native glyph.
@@ -1585,7 +1586,7 @@ class BaseGlyph(
         )
         return self.components[-1]
 
-    def removeComponent(self, component: Union[BaseComponent, int]) -> None:
+    def removeComponent(self, component: BaseComponent | int) -> None:
         """Remove the specified component from the glyph.
 
         :param component: The component to remove as a :class:`BaseComponent`
@@ -1693,7 +1694,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_anchors(self) -> Tuple[BaseAnchor, ...]:
+    def _get_anchors(self) -> tuple[BaseAnchor, ...]:
         """Get all anchors in the native glyph.
 
         :return: A :class:`tuple` of :class:`BaseAnthor` subclass instances.
@@ -1756,10 +1757,10 @@ class BaseGlyph(
 
     def appendAnchor(
         self,
-        name: Optional[str] = None,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        anchor: Optional[BaseAnchor] = None,
+        name: str | None = None,
+        position: PairCollectionType[IntFloatType] | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        anchor: BaseAnchor | None = None,
     ) -> BaseAnchor:
         """Append an anchor to the glyph.
 
@@ -1813,9 +1814,9 @@ class BaseGlyph(
     def _appendAnchor(
         self,  # type: ignore[return]
         name: str,
-        position: Optional[PairCollectionType[IntFloatType]],
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
-        identifier: Optional[str],
+        position: PairCollectionType[IntFloatType] | None,
+        color: QuadrupleCollectionType[IntFloatType] | None,
+        identifier: str | None,
         **kwargs: Any,
     ) -> BaseAnchor:
         r"""Append an anchor to the native glyph.
@@ -1842,7 +1843,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def removeAnchor(self, anchor: Union[BaseAnchor, int]) -> None:
+    def removeAnchor(self, anchor: BaseAnchor | int) -> None:
         """Remove the given anchor from the glyph.
 
         :param anchor: The anchor to remove as a :class:`BaseAnchor` intance,
@@ -1931,7 +1932,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_guidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_guidelines(self) -> tuple[BaseGuideline, ...]:
         """Get all guidelines in the glyph.
 
         This is the environment implementation of
@@ -2000,11 +2001,11 @@ class BaseGlyph(
 
     def appendGuideline(
         self,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
-        angle: Optional[IntFloatType] = None,
-        name: Optional[str] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        guideline: Optional[BaseGuideline] = None,
+        position: PairCollectionType[IntFloatType] | None = None,
+        angle: IntFloatType | None = None,
+        name: str | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        guideline: BaseGuideline | None = None,
     ) -> BaseGuideline:
         """Append a guideline to the glyph.
 
@@ -2029,7 +2030,7 @@ class BaseGlyph(
             >>> anchor = glyph.appendGuideline("top", (10, 20), color=(1, 0, 0, 1))
 
         """
-        identifier: Optional[str] = None
+        identifier: str | None = None
         if guideline is not None:
             guideline = normalizers.normalizeGuideline(guideline)
             if position is None:
@@ -2041,9 +2042,9 @@ class BaseGlyph(
             if color is None:
                 color = guideline.color
             if guideline.identifier is not None:
-                existing = set(
+                existing = {
                     g.identifier for g in self.guidelines if g.identifier is not None
-                )
+                }
                 if guideline.identifier not in existing:
                     identifier = guideline.identifier
         if position is not None:
@@ -2073,9 +2074,9 @@ class BaseGlyph(
         self,  # type: ignore[return]
         position: PairCollectionType[IntFloatType],
         angle: IntFloatType,
-        name: Optional[str],
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
-        identifier: Optional[str],
+        name: str | None,
+        color: QuadrupleCollectionType[IntFloatType] | None,
+        identifier: str | None,
         **kwargs: Any,
     ) -> BaseGuideline:
         r"""Append a guideline to the native glyph.
@@ -2104,7 +2105,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def removeGuideline(self, guideline: Union[BaseGuideline, int]) -> None:
+    def removeGuideline(self, guideline: BaseGuideline | int) -> None:
         """Remove the given guideline from the glyph.
 
         :param guideline: The guideline to remove as a :class:`BaseGuideline`
@@ -2288,8 +2289,8 @@ class BaseGlyph(
         """
         tempContourList: TempContourListType = []
         contourList: ContourListType = []
-        xThreshold: Optional[IntFloatType] = None
-        yThreshold: Optional[IntFloatType] = None
+        xThreshold: IntFloatType | None = None
+        yThreshold: IntFloatType | None = None
 
         for contour in self:
             bounds = contour.bounds
@@ -2366,7 +2367,7 @@ class BaseGlyph(
     def scaleBy(
         self,
         value: TransformationType,
-        origin: Optional[PairCollectionType[IntFloatType]] = None,
+        origin: PairCollectionType[IntFloatType] | None = None,
         width: bool = False,
         height: bool = False,
     ) -> None:
@@ -2396,9 +2397,9 @@ class BaseGlyph(
         normalizedOrigin = normalizers.normalizeCoordinateTuple(origin)
         if normalizedOrigin != (0, 0) and (width or height):
             raise FontPartsError(
-                ("The origin must not be set when scaling the width or height.")
+                "The origin must not be set when scaling the width or height."
             )
-        super(BaseGlyph, self).scaleBy(normalizedValue, origin=normalizedOrigin)
+        super().scaleBy(normalizedValue, origin=normalizedOrigin)
         sX, sY = normalizedValue
         if width:
             self._scaleWidthBy(sX)
@@ -2739,7 +2740,7 @@ class BaseGlyph(
 
     def _interpolate(
         self,
-        factor: Tuple[IntFloatType, IntFloatType],
+        factor: tuple[IntFloatType, IntFloatType],
         minGlyph: BaseGlyph,
         maxGlyph: BaseGlyph,
         round: bool,
@@ -2790,7 +2791,7 @@ class BaseGlyph(
 
     @staticmethod
     def _checkPairs(
-        object1: Any, object2: Any, reporter: Any, reporterObject: List[Any]
+        object1: Any, object2: Any, reporter: Any, reporterObject: list[Any]
     ) -> None:
         compatibility = object1.isCompatible(object2)[1]
         if compatibility.fatal or compatibility.warning:
@@ -2802,7 +2803,7 @@ class BaseGlyph(
 
     def isCompatible(
         self, other: BaseGlyph, cls=None
-    ) -> Tuple[bool, GlyphCompatibilityReporter]:
+    ) -> tuple[bool, GlyphCompatibilityReporter]:
         """Evaluate interpolation compatibility with another glyph.
 
         :param other: The other :class:`BaseGlyph` instance to check
@@ -2813,7 +2814,7 @@ class BaseGlyph(
             instance.
 
         """
-        return super(BaseGlyph, self).isCompatible(other, BaseGlyph)
+        return super().isCompatible(other, BaseGlyph)
 
     def _isCompatible(
         self, other: BaseGlyph, reporter: GlyphCompatibilityReporter
@@ -2832,7 +2833,7 @@ class BaseGlyph(
 
 
         """
-        GuidelineListType = List[Tuple[Optional[str], int]]
+        GuidelineListType = list[tuple[Optional[str], int]]
 
         glyph1 = self
         glyph2 = other
@@ -3001,13 +3002,13 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_bounds(self) -> Optional[QuadrupleType[IntFloatType]]:
+    def _get_base_bounds(self) -> QuadrupleType[IntFloatType] | None:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> Optional[QuadrupleType[IntFloatType]]:
+    def _get_bounds(self) -> QuadrupleType[IntFloatType] | None:
         """Get the bounds of the native glyph.
 
         This is the environment implementation of the :attr:`BaseGlyph.bounds`
@@ -3043,13 +3044,13 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_area(self) -> Optional[float]:
+    def _get_base_area(self) -> float | None:
         value = self._get_area()
         if value is not None:
             value = normalizers.normalizeArea(value)
         return value
 
-    def _get_area(self) -> Optional[float]:
+    def _get_area(self) -> float | None:
         """Get the area of the native glyph
 
         This is the environment implementation of the :attr:`BaseGlyph.area`
@@ -3087,7 +3088,7 @@ class BaseGlyph(
         """,
     )
 
-    def _get_layers(self, **kwargs) -> Tuple[BaseGlyph, ...]:
+    def _get_layers(self, **kwargs) -> tuple[BaseGlyph, ...]:
         r"""Get the layers of the native glyph.
 
         :param \**kwargs: Additional keyword arguments.
@@ -3193,7 +3194,7 @@ class BaseGlyph(
 
     # remove
 
-    def removeLayer(self, layer: Union[BaseGlyph, str]) -> None:
+    def removeLayer(self, layer: BaseGlyph | str) -> None:
         """Remove the specified layer from the glyph.
 
         :param name: The layer to remove as a :class:`BaseLayer` instance,
@@ -3243,14 +3244,14 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_image(self) -> Optional[BaseImage]:
+    def _get_base_image(self) -> BaseImage | None:
         image = self._get_image()
         if image is not None:
             if image.glyph is None:
                 image.glyph = self
         return image
 
-    def _get_image(self) -> Optional[BaseImage]:  # type: ignore[return]
+    def _get_image(self) -> BaseImage | None:  # type: ignore[return]
         """Get the image for the native glyph.
 
         :return: The :class:`BaseImage` subclass instance belonging to the glyph,
@@ -3267,11 +3268,11 @@ class BaseGlyph(
 
     def addImage(
         self,
-        path: Optional[str] = None,
-        data: Optional[bytes] = None,
-        scale: Optional[TransformationType] = None,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
+        path: str | None = None,
+        data: bytes | None = None,
+        scale: TransformationType | None = None,
+        position: PairCollectionType[IntFloatType] | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
     ) -> BaseImage:
         """Set the image in the glyph.
 
@@ -3332,7 +3333,7 @@ class BaseGlyph(
         transformation = (sx, 0, 0, sy, ox, oy)
         if path is not None:
             if not os.path.exists(path):
-                raise IOError(f"No image located at '{path}'.")
+                raise OSError(f"No image located at '{path}'.")
             with open(path, "rb") as f:
                 data = f.read()
         if data is not None:
@@ -3344,8 +3345,8 @@ class BaseGlyph(
     def _addImage(
         self,  # type: ignore[return]
         data: bytes,
-        transformation: Optional[SextupleCollectionType[IntFloatType]],
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
+        transformation: SextupleCollectionType[IntFloatType] | None,
+        color: QuadrupleCollectionType[IntFloatType] | None,
     ) -> BaseImage:
         """Set the image in the native glyph.
 
@@ -3411,21 +3412,21 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_markColor(self) -> Optional[Color]:
+    def _get_base_markColor(self) -> Color | None:
         value = self._get_markColor()
         if value is None:
             return None
         return Color(value)
 
     def _set_base_markColor(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_markColor(value)
 
     # type: ignore[return]
-    def _get_markColor(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:
+    def _get_markColor(self) -> QuadrupleCollectionType[IntFloatType] | None:
         """Get the glyph's mark color.
 
         This is the environment implementation of
@@ -3443,7 +3444,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def _set_markColor(self, value: Optional[QuadrupleType[float]]) -> None:
+    def _set_markColor(self, value: QuadrupleType[float] | None) -> None:
         """Set the glyph's mark color.
 
         This is the environment implementation of
@@ -3482,18 +3483,18 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_note(self) -> Optional[str]:
+    def _get_base_note(self) -> str | None:
         value = self._get_note()
         if value is not None:
             value = normalizers.normalizeGlyphNote(value)
         return value
 
-    def _set_base_note(self, value: Optional[str]) -> None:
+    def _set_base_note(self, value: str | None) -> None:
         if value is not None:
             value = normalizers.normalizeGlyphNote(value)
         self._set_note(value)
 
-    def _get_note(self) -> Optional[str]:  # type: ignore[return]
+    def _get_note(self) -> str | None:  # type: ignore[return]
         """Get the glyph's note.
 
         This is the environment implementation of the :attr:`BaseGlyph.note`
@@ -3510,7 +3511,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def _set_note(self, value: Optional[str]) -> None:
+    def _set_note(self, value: str | None) -> None:
         """Set the glyph's note.
 
         This is the environment implementation of the :attr:`BaseGlyph.note`
@@ -3724,14 +3725,14 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_selectedContours(self) -> Tuple[BaseContour, ...]:
+    def _get_base_selectedContours(self) -> tuple[BaseContour, ...]:
         selected = tuple(
             normalizers.normalizeContour(contour)
             for contour in self._get_selectedContours()
         )
         return selected
 
-    def _get_selectedContours(self) -> Tuple[BaseContour, ...]:
+    def _get_selectedContours(self) -> tuple[BaseContour, ...]:
         """Get the selected contours in the native glyph.
 
         This is the environment implementation of
@@ -3749,11 +3750,11 @@ class BaseGlyph(
         return self._getSelectedSubObjects(self.contours)
 
     def _set_base_selectedContours(
-        self, value: CollectionType[Union[BaseContour, int]]
+        self, value: CollectionType[BaseContour | int]
     ) -> None:
         normalized = []
         for contour in value:
-            normalizedContour: Union[BaseContour, int]
+            normalizedContour: BaseContour | int
             if isinstance(contour, int):
                 normalizedIndex = normalizers.normalizeIndex(contour)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -3766,7 +3767,7 @@ class BaseGlyph(
         self._set_selectedContours(normalized)
 
     def _set_selectedContours(
-        self, value: CollectionType[Union[BaseContour, int]]
+        self, value: CollectionType[BaseContour | int]
     ) -> None:
         """Set the selected contours in the glyph.
 
@@ -3811,14 +3812,14 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_selectedComponents(self) -> Tuple[BaseComponent, ...]:
+    def _get_base_selectedComponents(self) -> tuple[BaseComponent, ...]:
         selected = tuple(
             normalizers.normalizeComponent(component)
             for component in self._get_selectedComponents()
         )
         return selected
 
-    def _get_selectedComponents(self) -> Tuple[BaseComponent, ...]:
+    def _get_selectedComponents(self) -> tuple[BaseComponent, ...]:
         """Get the selected components in the native glyph.
 
         This is the environment implementation of
@@ -3836,11 +3837,11 @@ class BaseGlyph(
         return self._getSelectedSubObjects(self.components)
 
     def _set_base_selectedComponents(
-        self, value: CollectionType[Union[BaseComponent, int]]
+        self, value: CollectionType[BaseComponent | int]
     ) -> None:
         normalized = []
         for component in value:
-            normalizedComponent: Union[BaseComponent, int]
+            normalizedComponent: BaseComponent | int
             if isinstance(component, int):
                 normalizedIndex = normalizers.normalizeIndex(component)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -3853,7 +3854,7 @@ class BaseGlyph(
         self._set_selectedComponents(normalized)
 
     def _set_selectedComponents(
-        self, value: CollectionType[Union[BaseComponent, int]]
+        self, value: CollectionType[BaseComponent | int]
     ) -> None:
         """Set the selected components in the glyph.
 
@@ -3898,14 +3899,14 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_selectedAnchors(self) -> Tuple[BaseAnchor, ...]:
+    def _get_base_selectedAnchors(self) -> tuple[BaseAnchor, ...]:
         selected = tuple(
             normalizers.normalizeAnchor(anchor)
             for anchor in self._get_selectedAnchors()
         )
         return selected
 
-    def _get_selectedAnchors(self) -> Tuple[BaseAnchor, ...]:
+    def _get_selectedAnchors(self) -> tuple[BaseAnchor, ...]:
         """Get the selected anchors in the native glyph.
 
         This is the environment implementation of
@@ -3923,11 +3924,11 @@ class BaseGlyph(
         return self._getSelectedSubObjects(self.anchors)
 
     def _set_base_selectedAnchors(
-        self, value: CollectionType[Union[BaseAnchor, int]]
+        self, value: CollectionType[BaseAnchor | int]
     ) -> None:
         normalized = []
         for anchor in value:
-            normalizedAnchor: Union[BaseAnchor, int]
+            normalizedAnchor: BaseAnchor | int
             if isinstance(anchor, int):
                 normalizedIndex = normalizers.normalizeIndex(anchor)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -3940,7 +3941,7 @@ class BaseGlyph(
         self._set_selectedAnchors(normalized)
 
     def _set_selectedAnchors(
-        self, value: CollectionType[Union[BaseAnchor, int]]
+        self, value: CollectionType[BaseAnchor | int]
     ) -> None:
         """Set the selected anchors in the glyph.
 
@@ -3985,14 +3986,14 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_base_selectedGuidelines(self) -> tuple[BaseGuideline, ...]:
         selected = tuple(
             normalizers.normalizeGuideline(guideline)
             for guideline in self._get_selectedGuidelines()
         )
         return selected
 
-    def _get_selectedGuidelines(self) -> Tuple[BaseGuideline, ...]:
+    def _get_selectedGuidelines(self) -> tuple[BaseGuideline, ...]:
         """Get the selected guidelines in the native glyph.
 
         This is the environment implementation of
@@ -4010,11 +4011,11 @@ class BaseGlyph(
         return self._getSelectedSubObjects(self.guidelines)
 
     def _set_base_selectedGuidelines(
-        self, value: CollectionType[Union[BaseGuideline, int]]
+        self, value: CollectionType[BaseGuideline | int]
     ) -> None:
         normalized = []
         for guideline in value:
-            normalizedGuideline: Union[BaseGuideline, int]
+            normalizedGuideline: BaseGuideline | int
             if isinstance(guideline, int):
                 normalizedIndex = normalizers.normalizeIndex(guideline)
                 # Avoid mypy conflict with normalizeIndex -> Optional[int]
@@ -4027,7 +4028,7 @@ class BaseGlyph(
         self._set_selectedGuidelines(normalized)
 
     def _set_selectedGuidelines(
-        self, value: CollectionType[Union[BaseGuideline, int]]
+        self, value: CollectionType[BaseGuideline | int]
     ) -> None:
         """Set the selected guidelines in the glyph.
 

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -82,9 +82,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             return None
         return self._font()
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None and self._font != font:
             raise AssertionError("font for groups already set and is not same as font")
         if font is not None:

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -29,7 +29,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
     :cvar keyNormalizer: A function to normalize the key of the dictionary.
         Defaults to :func:`normalizers.normalizeGroupKey`
     :cvar valueNormalizer: A function to normalize the value of the dictionary.
-        Defaults to :func:`Normalizers.noramlizeGroupValue`
+        Defaults to :func:`normalizers.normalizeGroupValue`
 
     This object is normally created as part of a :class:`BaseFont`.
     An orphan :class:`BaseGroups` object instance can be created like this::
@@ -60,7 +60,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
 
     font: dynamicProperty = dynamicProperty(
         "font",
-        """Get or set the groups's parent font object.
+        """Get or set the groups' parent font object.
 
         The value must be a :class:`BaseFont` instance or :obj:`None`.
 

--- a/Lib/fontParts/base/groups.py
+++ b/Lib/fontParts/base/groups.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from collections.abc import Callable, Iterator
 from collections.abc import MutableMapping
 
 from fontParts.base.base import BaseDict, dynamicProperty, reference
@@ -13,8 +14,8 @@ if TYPE_CHECKING:
     from fontParts.base.base import BaseItems
     from fontParts.base.base import BaseValues
 
-ValueType = Tuple[str, ...]
-GroupsDict = Dict[str, ValueType]
+ValueType = tuple[str, ...]
+GroupsDict = dict[str, ValueType]
 
 
 class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
@@ -42,7 +43,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
         normalizers.normalizeGroupValue
     )
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.font is not None:
             contents.append("for font")
@@ -55,7 +56,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -76,13 +77,13 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is None:
             return None
         return self._font()
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None and self._font != font:
             raise AssertionError("font for groups already set and is not same as font")
@@ -94,7 +95,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
     # Searching
     # ---------
 
-    def findGlyph(self, glyphName: str) -> List[str]:
+    def findGlyph(self, glyphName: str) -> list[str]:
         """Retrieve the groups associated with the given glyph.
 
         :param glyphName: The name of the glyph to search for as a :class:`str`.
@@ -111,7 +112,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
         groupNames = self._findGlyph(glyphName)
         return [self._normalizeKey(groupName) for groupName in groupNames]
 
-    def _findGlyph(self, glyphName: str) -> List[str]:
+    def _findGlyph(self, glyphName: str) -> list[str]:
         """Retrieve the groups associated with the given native glyph.
 
         This is the environment implementation of :meth:`BaseGroups.findGlyph`.
@@ -279,7 +280,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             True
 
         """
-        return super(BaseGroups, self).__contains__(groupName)
+        return super().__contains__(groupName)
 
     def __delitem__(self, groupName: str) -> None:
         """Remove the given group from the current groups instance.
@@ -291,9 +292,9 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             >>> del font.groups["myGroup"]
 
         """
-        super(BaseGroups, self).__delitem__(groupName)
+        super().__delitem__(groupName)
 
-    def __getitem__(self, groupName: str) -> Tuple[str, ...]:
+    def __getitem__(self, groupName: str) -> tuple[str, ...]:
         """Get the contents of the given group.
 
         :param groupName: The group name to retrieve the value for as a :class:`str`.
@@ -316,7 +317,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
                 >>> font.groups["myGroup"] = group
 
         """
-        return super(BaseGroups, self).__getitem__(groupName)
+        return super().__getitem__(groupName)
 
     def __iter__(self) -> Iterator[str]:
         """Return an iterator over the keys in the current groups instance.
@@ -334,7 +335,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             "myGroup2"
 
         """
-        return super(BaseGroups, self).__iter__()
+        return super().__iter__()
 
     def __len__(self) -> int:
         """Return the number of groups in the current groups instance.
@@ -348,7 +349,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             5
 
         """
-        return super(BaseGroups, self).__len__()
+        return super().__len__()
 
     def __setitem__(self, groupName: str, glyphNames: CollectionType[str]) -> None:
         """Set the glyph names for a given group in the current groups instance.
@@ -363,7 +364,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
 
         """
 
-        super(BaseGroups, self).__setitem__(groupName, glyphNames)
+        super().__setitem__(groupName, glyphNames)
 
     def clear(self) -> None:
         """Remove all groups from the current groups instance.
@@ -375,11 +376,11 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             >>> font.groups.clear()
 
         """
-        super(BaseGroups, self).clear()
+        super().clear()
 
     def get(
-        self, groupName: str, default: Optional[CollectionType[str]] = None
-    ) -> Optional[Tuple[str, ...]]:
+        self, groupName: str, default: CollectionType[str] | None = None
+    ) -> tuple[str, ...] | None:
         """Get the contents for the given group in the current groups instance.
 
         If the given `groupName` is not found, The specified `default` will be
@@ -408,7 +409,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
                 >>> font.groups["myGroup"] = group
 
         """
-        return super(BaseGroups, self).get(groupName, default)
+        return super().get(groupName, default)
 
     def items(self) -> BaseItems[str, ValueType]:
         """Return the items in the current groups instance.
@@ -426,7 +427,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             ("myGroup2", ("D", "E", "F")), ...])
 
         """
-        return super(BaseGroups, self).items()
+        return super().items()
 
     def keys(self) -> BaseKeys:
         """Return the group names (keys) in the current groups instance.
@@ -439,7 +440,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             BaseGroups_keys(["myGroup4", "myGroup1", "myGroup5", ...])
 
         """
-        return super(BaseGroups, self).keys()
+        return super().keys()
 
     def values(self) -> BaseValues:
         """Return the values in the current groups instance.
@@ -453,11 +454,11 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             BaseGroups_values([("A", "B", "C"), ("D", "E", "F")]
 
         """
-        return super(BaseGroups, self).values()
+        return super().values()
 
     def pop(
-        self, groupName: str, default: Optional[CollectionType[str]] = None
-    ) -> Optional[Tuple[str, ...]]:
+        self, groupName: str, default: CollectionType[str] | None = None
+    ) -> tuple[str, ...] | None:
         """Remove the specified group and return its associated contents.
 
         If the `groupName` does not exist, the `default` value is returned.
@@ -475,7 +476,7 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             ("A", "B", "C")
 
         """
-        return super(BaseGroups, self).pop(groupName, default)
+        return super().pop(groupName, default)
 
     def update(self, otherGroups: MutableMapping[str, CollectionType[str]]) -> None:
         """Update the current groups instance with key-value pairs from another.
@@ -497,4 +498,4 @@ class BaseGroups(BaseDict, DeprecatedGroups, RemovedGroups):
             >>> font.groups.update(newGroups)
 
         """
-        super(BaseGroups, self).update(otherGroups)
+        super().update(otherGroups)

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, List, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Union, List, Tuple
+from collections.abc import Callable
 import math
 from fontTools.misc import transform
 from fontParts.base.base import (
@@ -48,9 +49,9 @@ class BaseGuideline(
 
     """
 
-    copyAttributes: Tuple[str, ...] = ("x", "y", "angle", "name", "color")
+    copyAttributes: tuple[str, ...] = ("x", "y", "angle", "name", "color")
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.name is not None:
             contents.append(f"'{self.name}'")
@@ -64,7 +65,7 @@ class BaseGuideline(
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph: dynamicProperty = dynamicProperty(
         "glyph",
@@ -84,13 +85,13 @@ class BaseGuideline(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._font is not None:
             raise AssertionError("font for guideline already set")
@@ -118,14 +119,14 @@ class BaseGuideline(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -143,7 +144,7 @@ class BaseGuideline(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is not None:
             return self._font()
         elif self._glyph is not None:
@@ -151,7 +152,7 @@ class BaseGuideline(
         return None
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None:
             raise AssertionError("font for guideline already set")
@@ -346,7 +347,7 @@ class BaseGuideline(
         value = normalizers.normalizeRotationAngle(value)
         return value
 
-    def _set_base_angle(self, value: Optional[IntFloatType]) -> None:
+    def _set_base_angle(self, value: IntFloatType | None) -> None:
         if value is None:
             if self._get_x() != 0 and self._get_y() != 0:
                 value = 0
@@ -359,7 +360,7 @@ class BaseGuideline(
         value = normalizers.normalizeRotationAngle(value)
         self._set_angle(value)
 
-    def _get_angle(self) -> Optional[IntFloatType]:
+    def _get_angle(self) -> IntFloatType | None:
         """Get the native guideline's angle.
 
         This is the environment implementation of the :attr:`BaseGuideline.angle`
@@ -378,7 +379,7 @@ class BaseGuideline(
         """
         self.raiseNotImplementedError()
 
-    def _set_angle(self, value: Optional[float]) -> None:
+    def _set_angle(self, value: float | None) -> None:
         """Set the native guideline's angle.
 
         This is the environment implementation of the :attr:`BaseGuideline.angle`
@@ -420,12 +421,12 @@ class BaseGuideline(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         value = self._get_index()
         value = normalizers.normalizeIndex(value)
         return value
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the native guideline's index.
 
         This is the environment implementation of the :attr:`BaseGuideline.index`
@@ -466,18 +467,18 @@ class BaseGuideline(
         """,
     )
 
-    def _get_base_name(self) -> Optional[str]:
+    def _get_base_name(self) -> str | None:
         value = self._get_name()
         if value is not None:
             value = normalizers.normalizeGuidelineName(value)
         return value
 
-    def _set_base_name(self, value: Optional[str]) -> None:
+    def _set_base_name(self, value: str | None) -> None:
         if value is not None:
             value = normalizers.normalizeGuidelineName(value)
         self._set_name(value)
 
-    def _get_name(self) -> Optional[str]:
+    def _get_name(self) -> str | None:
         """Get the native guideline's name.
 
         This is the environment implementation of the :attr:`BaseGuideline.name`
@@ -496,7 +497,7 @@ class BaseGuideline(
         """
         self.raiseNotImplementedError()
 
-    def _set_name(self, value: Optional[str]) -> None:
+    def _set_name(self, value: str | None) -> None:
         """Set the native guideline's name.
 
         This is the environment implementation of the :attr:`BaseGuideline.name`
@@ -535,20 +536,20 @@ class BaseGuideline(
         """,
     )
 
-    def _get_base_color(self) -> Optional[QuadrupleType[float]]:
+    def _get_base_color(self) -> QuadrupleType[float] | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
         return value
 
     def _set_base_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> Optional[QuadrupleType[float]]:
+    def _get_color(self) -> QuadrupleType[float] | None:
         """Get the native guideline's color.
 
         This is the environment implementation of the :attr:`BaseGuideline.color`
@@ -567,7 +568,7 @@ class BaseGuideline(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: Optional[QuadrupleType[float]]) -> None:
+    def _set_color(self, value: QuadrupleType[float] | None) -> None:
         """Set the native guideline's color.
 
         This is the environment implementation of the :attr:`BaseGuideline.color`
@@ -626,7 +627,7 @@ class BaseGuideline(
 
     def isCompatible(
         self, other: BaseGuideline, cls=None
-    ) -> Tuple[bool, GuidelineCompatibilityReporter]:
+    ) -> tuple[bool, GuidelineCompatibilityReporter]:
         """Evaluate interpolation compatibility with another guideline.
 
         :param other: The other :class:`BaseGuideline` instance to check
@@ -647,7 +648,7 @@ class BaseGuideline(
                                   name cap_height
 
         """
-        return super(BaseGuideline, self).isCompatible(other, BaseGuideline)
+        return super().isCompatible(other, BaseGuideline)
 
     def _isCompatible(
         self, other: BaseGuideline, reporter: GuidelineCompatibilityReporter

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -452,7 +452,7 @@ class BaseGuideline(
         "base_name",
         """Get or set the guideline's name.
 
-        The value must be a :class:`str` or :obj: `None`.
+        The value must be a :class:`str` or :obj:`None`.
 
         :return: A :class:`str` representing the name of the guideline, or :obj:`None`.
 

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -90,9 +90,7 @@ class BaseGuideline(
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._font is not None:
             raise AssertionError("font for guideline already set")
         if self._glyph is not None:
@@ -151,9 +149,7 @@ class BaseGuideline(
             return self.glyph.font
         return None
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None:
             raise AssertionError("font for guideline already set")
         if self._glyph is not None:

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
+from collections.abc import Callable
 
 from fontTools.misc import transform
 from fontParts.base.base import (
@@ -61,7 +62,7 @@ class BaseImage(
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph = dynamicProperty(
         "glyph",
@@ -81,13 +82,13 @@ class BaseImage(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for image already set")
@@ -113,7 +114,7 @@ class BaseImage(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
@@ -136,7 +137,7 @@ class BaseImage(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._glyph is None:
             return None
         return self.glyph.font
@@ -361,20 +362,20 @@ class BaseImage(
         """,
     )
 
-    def _get_base_color(self) -> Optional[Color]:
+    def _get_base_color(self) -> Color | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
         return value
 
     def _set_base_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:
+    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
         """Get the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`
@@ -393,7 +394,7 @@ class BaseImage(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: Optional[QuadrupleType[float]]) -> None:
+    def _set_color(self, value: QuadrupleType[float] | None) -> None:
         """Set the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`
@@ -426,13 +427,13 @@ class BaseImage(
         """,
     )
 
-    def _get_base_data(self) -> Optional[bytes]:
+    def _get_base_data(self) -> bytes | None:
         return self._get_data()
 
     def _set_base_data(self, value: bytes) -> None:
         self._set_data(value)
 
-    def _get_data(self) -> Optional[bytes]:
+    def _get_data(self) -> bytes | None:
         """Get the native image's raw byte data.
 
         This is the environment implementation of the :attr:`BaseImage.data`

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -87,9 +87,7 @@ class BaseImage(
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._glyph is not None:
             raise AssertionError("glyph for image already set")
         if glyph is not None:

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -214,11 +214,11 @@ class BaseImage(
 
     offset: dynamicProperty = dynamicProperty(
         "base_offset",
-        """Get or set the component's offset.
+        """Get or set the image's offset.
 
-        The value must be a :ref:`type-coordinate.`
+        The value must be a :ref:`type-coordinate`.
 
-        :return: A :ref:`type-coordinate.` representing the offset of the image.
+        :return: A :ref:`type-coordinate` representing the offset of the image.
 
         Example::
 
@@ -244,7 +244,7 @@ class BaseImage(
         This is the environment implementation of the :attr:`BaseImage.offset`
         property getter.
 
-        :return: A :ref:`type-coordinate.` representing the offset of the image.
+        :return: A :ref:`type-coordinate` representing the offset of the image.
             The value will be normalized
             with :func:`normalizers.normalizeTransformationOffset`.
 
@@ -262,7 +262,7 @@ class BaseImage(
         This is the environment implementation of the :attr:`BaseImage.offset`
         property setter.
 
-        :param value: The offset to set as a :ref:`type-coordinate.`. The value will
+        :param value: The offset to set as a :ref:`type-coordinate`. The value will
             have been normalized with :func:`normalizers.normalizeTransformationOffset`.
 
         .. note::
@@ -310,7 +310,7 @@ class BaseImage(
 
         :return: A :class:`tuple` of two :class:`float` items representing the
             ``(x, y)`` scale of the image. The value will have been normalized
-            with :func:`normalizers.normalizeComponentScale`.
+            with :func:`normalizers.normalizeTransformationScale`.
 
         .. note::
 
@@ -329,7 +329,7 @@ class BaseImage(
         :param value: The scale to set as a :class:`list` or :class:`tuple`
             of :class:`int` or :class:`float` items representing the ``(x, y)``
             scale of the image. The value will have been normalized
-            with :func:`normalizers.normalizeComponentScale`.
+            with :func:`normalizers.normalizeTransformationScale`.
 
         .. note::
 
@@ -346,7 +346,7 @@ class BaseImage(
         "base_color",
         """Get or set the image's color.
 
-        The value must be a :ref:`type-color` or :obj`None`.
+        The value must be a :ref:`type-color` or :obj:`None`.
 
         :return: A :class:`Color` instance representing the color of the image,
             or :obj:`None`.
@@ -494,7 +494,7 @@ class BaseImage(
     # -------------
 
     def round(self) -> None:
-        """Round the images's offset coordinates.
+        """Round the image's offset coordinates.
 
         Example::
 
@@ -504,7 +504,7 @@ class BaseImage(
         self._round()
 
     def _round(self) -> None:
-        """Round the native images's offset coordinates.
+        """Round the native image's offset coordinates.
 
         This is the environment implementation of :meth:`BaseImage.round`.
 

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -509,9 +509,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
             return None
         return self._font()
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None and self._font != font:
             raise AssertionError("font for info already set and is not same as font")
         if font is not None:

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
+from collections.abc import Callable
 
 from fontTools.ufoLib import fontInfoAttributesVersion3
 from fontTools.ufoLib import validateFontInfoVersion3ValueForAttribute
@@ -19,62 +20,62 @@ if TYPE_CHECKING:
 class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     """Represent the basis for a font info object."""
 
-    familyName: Optional[str]
+    familyName: str | None
     """Family name."""
 
-    styleName: Optional[str]
+    styleName: str | None
     """Style name."""
 
-    styleMapFamilyName: Optional[str]
+    styleMapFamilyName: str | None
     """Family name used for bold, italic and bold italic style mapping."""
 
-    styleMapStyleName: Optional[str]
+    styleMapStyleName: str | None
     """Style map style.
 
     The possible values are *regular*, *italic*, *bold* and *bold italic*.
     These are case sensitive."""
 
-    versionMajor: Optional[int]
+    versionMajor: int | None
     """Major version."""
 
-    versionMinor: Optional[int]
+    versionMinor: int | None
     """Minor version."""
 
-    year: Optional[int]
+    year: int | None
     """The year the font was created.
 
     This attribute is deprecated as of version 2. It's presence should not
     be relied upon by applications. However, it may occur in a font's info
     so applications should preserve it if present."""
 
-    copyright: Optional[str]
+    copyright: str | None
     """Copyright statement."""
 
-    trademark: Optional[str]
+    trademark: str | None
     """Trademark statement."""
 
-    unitsPerEm: Union[int, float]
+    unitsPerEm: int | float
     """Units per em."""
 
-    descender: Union[int, float]
+    descender: int | float
     """Descender value."""
 
-    xHeight: Union[int, float]
+    xHeight: int | float
     """x-height value."""
 
-    capHeight: Union[int, float]
+    capHeight: int | float
     """Cap height value."""
 
-    ascender: Union[int, float]
+    ascender: int | float
     """Ascender value."""
 
-    italicAngle: Union[int, float]
+    italicAngle: int | float
     """Italic angle."""
 
-    note: Optional[str]
+    note: str | None
     """Arbitrary note about the font."""
 
-    openTypeHeadCreated: Optional[str]
+    openTypeHeadCreated: str | None
     """Creation date.
 
     Expressed as a string of the format "YYYY/MM/DD HH:MM:SS". "YYYY/MM/DD"
@@ -83,135 +84,135 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     The hour should be in the range 0:23. The minute and second should each
     be in the range 0-59."""
 
-    openTypeHeadLowestRecPPEM: Union[int, float]
+    openTypeHeadLowestRecPPEM: int | float
     """Smallest readable size in pixels.
 
     Corresponds to the OpenType head table lowestRecPPEM field."""
 
-    openTypeHeadFlags: Optional[list[int]]
+    openTypeHeadFlags: list[int] | None
     """A list of bit numbers indicating the flags.
 
     The bit numbers are listed in the OpenType head specification.
     Corresponds to the OpenType head table flags field."""
 
-    openTypeHheaAscender: Union[int, float]
+    openTypeHheaAscender: int | float
     """Ascender value.
 
     Corresponds to the OpenType hhea table Ascender field."""
 
-    openTypeHheaDescender: Union[int, float]
+    openTypeHheaDescender: int | float
     """Descender value.
 
     Corresponds to the OpenType hhea table Descender field."""
 
-    openTypeHheaLineGap: Union[int, float]
+    openTypeHheaLineGap: int | float
     """Line gap value.
 
     Corresponds to the OpenType hhea table LineGap field."""
 
-    openTypeHheaCaretSlopeRise: Optional[int]
+    openTypeHheaCaretSlopeRise: int | None
     """Caret slope rise value.
 
     Corresponds to the OpenType hhea table caretSlopeRise field."""
 
-    openTypeHheaCaretSlopeRun: Optional[int]
+    openTypeHheaCaretSlopeRun: int | None
     """Caret slope run value.
 
     Corresponds to the OpenType hhea table caretSlopeRun field."""
 
-    openTypeHheaCaretOffset: Union[int, float]
+    openTypeHheaCaretOffset: int | float
     """Caret offset value.
 
     Corresponds to the OpenType hhea table caretOffset field."""
 
-    openTypeNameDesigner: Optional[str]
+    openTypeNameDesigner: str | None
     """Designer name.
 
     Corresponds to the OpenType name table name ID 9."""
 
-    openTypeNameDesignerURL: Optional[str]
+    openTypeNameDesignerURL: str | None
     """URL for the designer.
 
     Corresponds to the OpenType name table name ID 12."""
 
-    openTypeNameManufacturer: Optional[str]
+    openTypeNameManufacturer: str | None
     """Manufacturer name.
 
     Corresponds to the OpenType name table name ID 8."""
 
-    openTypeNameManufacturerURL: Optional[str]
+    openTypeNameManufacturerURL: str | None
     """Manufacturer URL.
 
     Corresponds to the OpenType name table name ID 11."""
 
-    openTypeNameLicense: Optional[str]
+    openTypeNameLicense: str | None
     """License text.
 
     Corresponds to the OpenType name table name ID 13."""
 
-    openTypeNameLicenseURL: Optional[str]
+    openTypeNameLicenseURL: str | None
     """URL for the license.
 
     Corresponds to the OpenType name table name ID 14."""
 
-    openTypeNameVersion: Optional[str]
+    openTypeNameVersion: str | None
     """Version string.
 
     Corresponds to the OpenType name table name ID 5."""
 
-    openTypeNameUniqueID: Optional[str]
+    openTypeNameUniqueID: str | None
     """Unique ID string.
 
     Corresponds to the OpenType name table name ID 3."""
 
-    openTypeNameDescription: Optional[str]
+    openTypeNameDescription: str | None
     """Description of the font.
 
     Corresponds to the OpenType name table name ID 10."""
 
-    openTypeNamePreferredFamilyName: Optional[str]
+    openTypeNamePreferredFamilyName: str | None
     """Preferred family name.
 
     Corresponds to the OpenType name table name ID 16."""
 
-    openTypeNamePreferredSubfamilyName: Optional[str]
+    openTypeNamePreferredSubfamilyName: str | None
     """Preferred subfamily name.
 
     Corresponds to the OpenType name table name ID 17."""
 
-    openTypeNameCompatibleFullName: Optional[str]
+    openTypeNameCompatibleFullName: str | None
     """Compatible full name.
 
     Corresponds to the OpenType name table name ID 18."""
 
-    openTypeNameSampleText: Optional[str]
+    openTypeNameSampleText: str | None
     """Sample text.
 
     Corresponds to the OpenType name table name ID 20."""
 
-    openTypeNameWWSFamilyName: Optional[str]
+    openTypeNameWWSFamilyName: str | None
     """WWS family name.
 
     Corresponds to the OpenType name table name ID 21."""
 
-    openTypeNameWWSSubfamilyName: Optional[str]
+    openTypeNameWWSSubfamilyName: str | None
     """WWS Subfamily name.
 
     Corresponds to the OpenType name table name ID 22."""
 
-    openTypeOS2WidthClass: Optional[int]
+    openTypeOS2WidthClass: int | None
     """Width class value.
 
     Must be in the range 1-9. Corresponds to the OpenType OS/2 table
     usWidthClass field."""
 
-    openTypeOS2WeightClass: Optional[int]
+    openTypeOS2WeightClass: int | None
     """Weight class value.
 
     Must be a positive integer. Corresponds to the OpenType OS/2 table
     usWeightClass field."""
 
-    openTypeOS2Selection: Optional[list[int]]
+    openTypeOS2Selection: list[int] | None
     """A list of bit numbers indicating the bits that should be set in fsSelection.
 
     The bit numbers are listed in the OpenType OS/2 specification.
@@ -219,18 +220,18 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     (italic), 5 (bold) and 6 (regular) should not be set here. These bits
     should be taken from the generic *styleMapStyleName* attribute."""
 
-    openTypeOS2VendorID: Optional[str]
+    openTypeOS2VendorID: str | None
     """Four character identifier for the creator of the font.
 
     Corresponds to the OpenType OS/2 table achVendID field."""
 
-    openTypeOS2Panose: Optional[list[int]]
+    openTypeOS2Panose: list[int] | None
     """The list should contain 10 integers that represent the setting for each category in the Panose specification.
 
     The integers correspond with the option numbers in each of the Panose
     categories. This corresponds to the OpenType OS/2 table Panose field."""
 
-    openTypeOS2FamilyClass: Optional[list[int]]
+    openTypeOS2FamilyClass: list[int] | None
     """Two integers representing the IBM font class and font subclass of the font.
 
     The first number, representing the class ID, should be in the range
@@ -238,230 +239,230 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     range 0-15. The numbers are listed in the OpenType OS/2 specification.
     Corresponds to the OpenType OS/2 table sFamilyClass field."""
 
-    openTypeOS2UnicodeRanges: Optional[list[int]]
+    openTypeOS2UnicodeRanges: list[int] | None
     """A list of bit numbers that are supported Unicode ranges in the font.
 
     The bit numbers are listed in the OpenType OS/2 specification.
     Corresponds to the OpenType OS/2 table ulUnicodeRange1, ulUnicodeRange2,
     ulUnicodeRange3 and ulUnicodeRange4 fields."""
 
-    openTypeOS2CodePageRanges: Optional[list[int]]
+    openTypeOS2CodePageRanges: list[int] | None
     """A list of bit numbers that are supported code page ranges in the font.
 
     The bit numbers are listed in the OpenType OS/2 specification.
     Corresponds to the OpenType OS/2 table ulCodePageRange1 and
     ulCodePageRange2 fields."""
 
-    openTypeOS2TypoAscender: Union[int, float]
+    openTypeOS2TypoAscender: int | float
     """Ascender value.
 
     Corresponds to the OpenType OS/2 table sTypoAscender field."""
 
-    openTypeOS2TypoDescender: Union[int, float]
+    openTypeOS2TypoDescender: int | float
     """Descender value.
 
     Corresponds to the OpenType OS/2 table sTypoDescender field."""
 
-    openTypeOS2TypoLineGap: Union[int, float]
+    openTypeOS2TypoLineGap: int | float
     """Line gap value.
 
     Corresponds to the OpenType OS/2 table sTypoLineGap field."""
 
-    openTypeOS2WinAscent: Union[int, float]
+    openTypeOS2WinAscent: int | float
     """Ascender value.
 
     Corresponds to the OpenType OS/2 table usWinAscent field."""
 
-    openTypeOS2WinDescent: Union[int, float]
+    openTypeOS2WinDescent: int | float
     """Descender value.
 
     Corresponds to the OpenType OS/2 table usWinDescent field."""
 
-    openTypeOS2Type: Optional[list[int]]
+    openTypeOS2Type: list[int] | None
     """A list of bit numbers indicating the embedding type.
 
     The bit numbers are listed in the OpenType OS/2 specification.
     Corresponds to the OpenType OS/2 table fsType field."""
 
-    openTypeOS2SubscriptXSize: Union[int, float]
+    openTypeOS2SubscriptXSize: int | float
     """Subscript horizontal font size.
 
     Corresponds to the OpenType OS/2 table ySubscriptXSize field."""
 
-    openTypeOS2SubscriptYSize: Union[int, float]
+    openTypeOS2SubscriptYSize: int | float
     """Subscript vertical font size.
 
     Corresponds to the OpenType OS/2 table ySubscriptYSize field."""
 
-    openTypeOS2SubscriptXOffset: Union[int, float]
+    openTypeOS2SubscriptXOffset: int | float
     """Subscript x offset.
 
     Corresponds to the OpenType OS/2 table ySubscriptXOffset field."""
 
-    openTypeOS2SubscriptYOffset: Union[int, float]
+    openTypeOS2SubscriptYOffset: int | float
     """Subscript y offset.
 
     Corresponds to the OpenType OS/2 table ySubscriptYOffset field."""
 
-    openTypeOS2SuperscriptXSize: Union[int, float]
+    openTypeOS2SuperscriptXSize: int | float
     """Superscript horizontal font size.
 
     Corresponds to the OpenType OS/2 table ySuperscriptXSize field."""
 
-    openTypeOS2SuperscriptYSize: Union[int, float]
+    openTypeOS2SuperscriptYSize: int | float
     """Superscript vertical font size.
 
     Corresponds to the OpenType OS/2 table ySuperscriptYSize field."""
 
-    openTypeOS2SuperscriptXOffset: Union[int, float]
+    openTypeOS2SuperscriptXOffset: int | float
     """Superscript x offset.
 
     Corresponds to the OpenType OS/2 table ySuperscriptXOffset field."""
 
-    openTypeOS2SuperscriptYOffset: Union[int, float]
+    openTypeOS2SuperscriptYOffset: int | float
     """Superscript y offset.
 
     Corresponds to the OpenType OS/2 table ySuperscriptYOffset field."""
 
-    openTypeOS2StrikeoutSize: Union[int, float]
+    openTypeOS2StrikeoutSize: int | float
     """Strikeout size.
 
     Corresponds to the OpenType OS/2 table yStrikeoutSize field."""
 
-    openTypeOS2StrikeoutPosition: Union[int, float]
+    openTypeOS2StrikeoutPosition: int | float
     """Strikeout position.
 
     Corresponds to the OpenType OS/2 table yStrikeoutPosition field."""
 
-    openTypeVheaVertTypoAscender: Union[int, float]
+    openTypeVheaVertTypoAscender: int | float
     """Ascender value.
 
     Corresponds to the OpenType vhea table vertTypoAscender field."""
 
-    openTypeVheaVertTypoDescender: Union[int, float]
+    openTypeVheaVertTypoDescender: int | float
     """Descender value.
 
     Corresponds to the OpenType vhea table vertTypoDescender field."""
 
-    openTypeVheaVertTypoLineGap: Union[int, float]
+    openTypeVheaVertTypoLineGap: int | float
     """Line gap value.
 
     Corresponds to the OpenType vhea table vertTypoLineGap field."""
 
-    openTypeVheaCaretSlopeRise: Optional[int]
+    openTypeVheaCaretSlopeRise: int | None
     """Caret slope rise value.
 
     Corresponds to the OpenType vhea table caretSlopeRise field."""
 
-    openTypeVheaCaretSlopeRun: Optional[int]
+    openTypeVheaCaretSlopeRun: int | None
     """Caret slope run value.
 
     Corresponds to the OpenType vhea table caretSlopeRun field."""
 
-    openTypeVheaCaretOffset: Union[int, float]
+    openTypeVheaCaretOffset: int | float
     """Caret offset value.
 
     Corresponds to the OpenType vhea table caretOffset field."""
 
-    postscriptFontName: Optional[str]
+    postscriptFontName: str | None
     """Name to be used for the *FontName* field in Type 1/CFF table."""
 
-    postscriptFullName: Optional[str]
+    postscriptFullName: str | None
     """Name to be used for the *FullName* field in Type 1/CFF table."""
 
-    postscriptSlantAngle: Union[int, float]
+    postscriptSlantAngle: int | float
     """Artificial slant angle."""
 
-    postscriptUniqueID: Optional[int]
+    postscriptUniqueID: int | None
     """A unique ID number as defined in the Type 1/CFF specification."""
 
-    postscriptUnderlineThickness: Union[int, float]
+    postscriptUnderlineThickness: int | float
     """Underline thickness value.
 
     Corresponds to the Type 1/CFF/post table UnderlineThickness field."""
 
-    postscriptUnderlinePosition: Union[int, float]
+    postscriptUnderlinePosition: int | float
     """Underline position value.
 
     Corresponds to the Type 1/CFF/post table UnderlinePosition field."""
 
-    postscriptIsFixedPitch: Optional[bool]
+    postscriptIsFixedPitch: bool | None
     """Indicates if the font is monospaced.
 
     A compiler could calculate this automatically, but the designer may wish
     to override this setting. This corresponds to the Type 1/CFF
     isFixedPitched field"""
 
-    postscriptBlueValues: Optional[list[int]]
+    postscriptBlueValues: list[int] | None
     """A list of up to 14 integers or floats specifying the values that should be in the Type 1/CFF BlueValues field.
 
     This list must contain an even number of integers following the rules
     defined in the Type 1/CFF specification."""
 
-    postscriptOtherBlues: Optional[list[int]]
+    postscriptOtherBlues: list[int] | None
     """A list of up to 10 integers or floats specifying the values that should be in the Type 1/CFF OtherBlues field.
 
     This list must contain an even number of integers following the rules
     defined in the Type 1/CFF specification."""
 
-    postscriptFamilyBlues: Optional[list[int]]
+    postscriptFamilyBlues: list[int] | None
     """A list of up to 14 integers or floats specifying the values that should be in the Type 1/CFF FamilyBlues field.
 
     This list must contain an even number of integers following the rules
     defined in the Type 1/CFF specification."""
 
-    postscriptFamilyOtherBlues: Optional[list[int]]
+    postscriptFamilyOtherBlues: list[int] | None
     """A list of up to 10 integers or floats specifying the values that should be in the Type 1/CFF FamilyOtherBlues field.
 
     This list must contain an even number of integers following the rules
     defined in the Type 1/CFF specification."""
 
-    postscriptStemSnapH: Optional[list[int]]
+    postscriptStemSnapH: list[int] | None
     """List of horizontal stems sorted in increasing order.
 
     Up to 12 integers or floats are possible. This corresponds to the Type
     1/CFF StemSnapH field."""
 
-    postscriptStemSnapV: Optional[list[int]]
+    postscriptStemSnapV: list[int] | None
     """List of vertical stems sorted in increasing order.
 
     Up to 12 integers or floats are possible. This corresponds to the Type
     1/CFF StemSnapV field."""
 
-    postscriptBlueFuzz: Union[int, float]
+    postscriptBlueFuzz: int | float
     """BlueFuzz value.
 
     This corresponds to the Type 1/CFF BlueFuzz field."""
 
-    postscriptBlueShift: Union[int, float]
+    postscriptBlueShift: int | float
     """BlueShift value.
 
     This corresponds to the Type 1/CFF BlueShift field."""
 
-    postscriptBlueScale: Union[int, float]
+    postscriptBlueScale: int | float
     """BlueScale value.
 
     This corresponds to the Type 1/CFF BlueScale field."""
 
-    postscriptForceBold: Optional[bool]
+    postscriptForceBold: bool | None
     """Indicates how the Type 1/CFF ForceBold field should be set."""
 
-    postscriptDefaultWidthX: Union[int, float]
+    postscriptDefaultWidthX: int | float
     """Default width for glyphs."""
 
-    postscriptNominalWidthX: Union[int, float]
+    postscriptNominalWidthX: int | float
     """Nominal width for glyphs."""
 
-    postscriptWeightName: Optional[str]
+    postscriptWeightName: str | None
     """A string indicating the overall weight of the font.
 
     This corresponds to the Type 1/CFF Weight field. It should be in sync
     with the openTypeOS2WeightClass value."""
 
-    postscriptDefaultCharacter: Optional[str]
+    postscriptDefaultCharacter: str | None
     """The name of the glyph that should be used as the default character in PFM files."""
 
-    postscriptWindowsCharacterSet: Optional[int]
+    postscriptWindowsCharacterSet: int | None
     """The Windows character set.
 
     The values are defined below."""
@@ -470,7 +471,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
     fontInfoAttributes.remove("guidelines")
     copyAttributes = tuple(fontInfoAttributes)
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.font is not None:
             contents.append("for font")
@@ -483,7 +484,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -503,13 +504,13 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is None:
             return None
         return self._font()
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None and self._font != font:
             raise AssertionError("font for info already set and is not same as font")
@@ -551,7 +552,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
             if value is not None:
                 value = self._validateFontInfoAttributeValue(attr, value)
             return value
-        return super(BaseInfo, self).__getattribute__(attr)
+        return super().__getattribute__(attr)
 
     def _getAttr(self, attr: str) -> Any:
         """Get the value of the specified native font info attribute.
@@ -598,7 +599,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
             if value is not None:
                 value = self._validateFontInfoAttributeValue(attr, value)
             return self._setAttr(attr, value)
-        return super(BaseInfo, self).__setattr__(attr, value)
+        return super().__setattr__(attr, value)
 
     def _setAttr(self, attr: str, value: Any) -> None:
         """Set the value of the specified native font info attribute.
@@ -690,7 +691,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
         self._round()
 
     def _round(self, **kwargs: Any) -> None:
-        """Round selected native attributes to the nearest integer.
+        r"""Round selected native attributes to the nearest integer.
 
         This is the environment implementation of :meth:`BaseInfo.round`.
 
@@ -902,7 +903,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
 
         minInfo = minInfo._toMathInfo()
         maxInfo = maxInfo._toMathInfo()
-        result: Optional[MathInfo] = interpolate(minInfo, maxInfo, factor)
+        result: MathInfo | None = interpolate(minInfo, maxInfo, factor)
         if result is None:
             if not suppressError:
                 raise FontPartsError(

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -559,9 +559,9 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return super().items()
 
     def keys(self) -> BaseKeys[PairType[str]]:
-        """Return the kering's pairs (keys).
+        """Return the kerning's pairs (keys).
 
-        :return: A :ref:`type-view` of the kerning's pairs as :class: `tuple` instances
+        :return: A :ref:`type-view` of the kerning's pairs as :class:`tuple` instances
             of two :class:`str` values.
 
         Example::

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -1,13 +1,6 @@
 # pylint: disable=C0103, C0114
 from __future__ import annotations
-from typing import (
-    TYPE_CHECKING,
-    Dict,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 from collections.abc import Callable, Iterator
 from collections.abc import MutableMapping
 
@@ -95,9 +88,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             return None
         return self._font()
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError("font for kerning already set and is not same as font")
         if font is not None:

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -2,14 +2,13 @@
 from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
-    Callable,
     Dict,
-    Iterator,
     List,
     Optional,
     TypeVar,
     Union,
 )
+from collections.abc import Callable, Iterator
 from collections.abc import MutableMapping
 
 from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
@@ -58,7 +57,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         normalizers.normalizeKerningValue
     )
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.font is not None:
             contents.append("for font")
@@ -71,7 +70,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -91,13 +90,13 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is None:
             return None
         return self._font()
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError("font for kerning already set and is not same as font")
@@ -339,7 +338,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         del self[pair]
 
-    def asDict(self, returnIntegers: bool = True) -> Dict[PairType[str], IntFloatType]:
+    def asDict(self, returnIntegers: bool = True) -> dict[PairType[str], IntFloatType]:
         """Return the kerning as a dictionary.
 
         :return A :class:`dict` reflecting the contents of the kerning.
@@ -376,7 +375,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             True
 
         """
-        return super(BaseKerning, self).__contains__(pair)
+        return super().__contains__(pair)
 
     def __delitem__(self, pair: PairType[str]) -> None:
         """Remove the given pair from the kerning.
@@ -388,7 +387,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> del font.kerning[("A","V")]
 
         """
-        super(BaseKerning, self).__delitem__(pair)
+        super().__delitem__(pair)
 
     def __getitem__(self, pair: PairType[str]) -> IntFloatType:
         """Get the value associated with the given kerning pair.
@@ -412,7 +411,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
                 >>> font.kerning[("A", "V")] = value
 
         """
-        return super(BaseKerning, self).__getitem__(pair)
+        return super().__getitem__(pair)
 
     def __iter__(self) -> Iterator[PairType[str]]:
         """Return an iterator over the pairs in the kerning.
@@ -431,7 +430,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             ("A", "W")
 
         """
-        return super(BaseKerning, self).__iter__()
+        return super().__iter__()
 
     def __len__(self) -> int:
         """Return the number of pairs in the kerning.
@@ -444,7 +443,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             5
 
         """
-        return super(BaseKerning, self).__len__()
+        return super().__len__()
 
     def __setitem__(self, pair: PairType[str], value: IntFloatType) -> None:
         """Set the value for the given kerning pair.
@@ -458,7 +457,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> font.kerning[("A", "W")] = -10.5
 
         """
-        super(BaseKerning, self).__setitem__(pair, value)
+        super().__setitem__(pair, value)
 
     def clear(self) -> None:
         """Remove all information from kerning.
@@ -470,11 +469,11 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> font.kerning.clear()
 
         """
-        super(BaseKerning, self).clear()
+        super().clear()
 
     def get(
-        self, pair: PairType[str], default: Optional[IntFloatType] = None
-    ) -> Optional[IntFloatType]:
+        self, pair: PairType[str], default: IntFloatType | None = None
+    ) -> IntFloatType | None:
         """Get the value for the given kerning pair.
 
         If the given `pair` is not found, The specified `default` will be returned.
@@ -500,11 +499,11 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
                 >>> font.kerning[("A", "V")] = value
 
         """
-        return super(BaseKerning, self).get(pair, default)
+        return super().get(pair, default)
 
     def find(
-        self, pair: PairCollectionType[str], default: Optional[IntFloatType] = None
-    ) -> Optional[IntFloatType]:
+        self, pair: PairCollectionType[str], default: IntFloatType | None = None
+    ) -> IntFloatType | None:
         """Get the value for the given explicit or implicit kerning pair.
 
         This method will return the value for the given `pair`, even if it only exists
@@ -529,8 +528,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return value
 
     def _find(
-        self, pair: PairType[str], default: Optional[IntFloatType] = None
-    ) -> Optional[IntFloatType]:
+        self, pair: PairType[str], default: IntFloatType | None = None
+    ) -> IntFloatType | None:
         """Get the value for the given explicit or implicit native kerning pair.
 
         This is the environment implementation of :attr:`BaseKerning.find`.
@@ -566,7 +565,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             BaseKerning_items([(("A", "V"), -30), (("A", "W"), -10)])
 
         """
-        return super(BaseKerning, self).items()
+        return super().items()
 
     def keys(self) -> BaseKeys[PairType[str]]:
         """Return the kering's pairs (keys).
@@ -580,7 +579,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             BaseKerning_keys([("A", "Y"), ("A", "V"), ("A", "W")])
 
         """
-        return super(BaseKerning, self).keys()
+        return super().keys()
 
     def values(self) -> BaseValues[IntFloatType]:
         """Return the kerning's values.
@@ -593,11 +592,11 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             BaseKerning_values([-20, -15, 5, 3.5])
 
         """
-        return super(BaseKerning, self).values()
+        return super().values()
 
     def pop(
-        self, pair: PairType[str], default: Optional[IntFloatType] = None
-    ) -> Optional[IntFloatType]:
+        self, pair: PairType[str], default: IntFloatType | None = None
+    ) -> IntFloatType | None:
         """Remove the specified kerning pair and return its associated value.
 
         If the `pair` does not exist, the `default` value is returned.
@@ -617,7 +616,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             -10.5
 
         """
-        return super(BaseKerning, self).pop(pair, default)
+        return super().pop(pair, default)
 
     def update(self, otherKerning: MutableMapping[PairType[str], IntFloatType]) -> None:
         """Update the current kerning with key-value pairs from another.
@@ -639,4 +638,4 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> font.kerning.update(newKerning)
 
         """
-        super(BaseKerning, self).update(otherKerning)
+        super().update(otherKerning)

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -718,9 +718,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             return None
         return self._font()
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None:
             raise AssertionError("font for layer already set")
         if font is not None:

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -1,7 +1,8 @@
 # pylint: disable=C0103, C0302, C0114, W0613
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from collections.abc import Callable, Iterator
 import collections
 
 from fontParts.base.base import (
@@ -193,7 +194,7 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin, ABC):
             raise KeyError(f"No glyph named '{name}'.")
         self._removeGlyph(name)
 
-    def keys(self) -> Tuple[str, ...]:
+    def keys(self) -> tuple[str, ...]:
         """Get the names of all glyphs in the layer.
 
         This method returns an unordered :class:`tuple` of glyph names
@@ -214,7 +215,7 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin, ABC):
         """
         return self._keys()
 
-    def _keys(self, **kwargs: Any) -> Tuple[str, ...]:  # type: ignore[return]
+    def _keys(self, **kwargs: Any) -> tuple[str, ...]:  # type: ignore[return]
         r"""Get the names of all glyphs in the native layer.
 
         This is the environment implementation of
@@ -400,7 +401,7 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin, ABC):
         """
         self.raiseNotImplementedError()
 
-    def insertGlyph(self, glyph: BaseGlyph, name: Optional[str] = None) -> BaseGlyph:
+    def insertGlyph(self, glyph: BaseGlyph, name: str | None = None) -> BaseGlyph:
         """Insert a specified glyph into the layer.
 
         .. deprecated::
@@ -484,13 +485,13 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin, ABC):
         """,
     )
 
-    def _get_base_selectedGlyphs(self) -> Tuple[BaseGlyph, ...]:
+    def _get_base_selectedGlyphs(self) -> tuple[BaseGlyph, ...]:
         selected = tuple(
             normalizers.normalizeGlyph(glyph) for glyph in self._get_selectedGlyphs()
         )
         return selected
 
-    def _get_selectedGlyphs(self) -> Tuple[BaseGlyph, ...]:
+    def _get_selectedGlyphs(self) -> tuple[BaseGlyph, ...]:
         """Get the selected glyphs in the native layer.
 
         This is the environment implementation of
@@ -550,14 +551,14 @@ class _BaseGlyphVendor(BaseObject, SelectionMixin, ABC):
         """,
     )
 
-    def _get_base_selectedGlyphNames(self) -> Tuple[str, ...]:
+    def _get_base_selectedGlyphNames(self) -> tuple[str, ...]:
         selected = tuple(
             normalizers.normalizeGlyphName(name)
             for name in self._get_selectedGlyphNames()
         )
         return selected
 
-    def _get_selectedGlyphNames(self) -> Tuple[str, ...]:
+    def _get_selectedGlyphNames(self) -> tuple[str, ...]:
         """Get the selected glyph names in the layer.
 
         This is the environment implementation of
@@ -635,8 +636,8 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
     """
 
-    def _reprContents(self) -> List[str]:
-        contents: List[str] = [f"'{self.name}'"]
+    def _reprContents(self) -> list[str]:
+        contents: list[str] = [f"'{self.name}'"]
         if self.color:
             contents.append(f"color={self.color!r}")
         return contents
@@ -645,7 +646,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
     # Copy
     # ----
 
-    copyAttributes: Tuple[str, ...] = ("name", "color", "lib")
+    copyAttributes: tuple[str, ...] = ("name", "color", "lib")
 
     def copy(self) -> BaseLayer:
         """Copy data from the current layer into a new layer.
@@ -664,7 +665,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             >>> copiedLayer = layer.copy()
 
         """
-        return super(BaseLayer, self).copy()
+        return super().copy()
 
     def copyData(self, source: BaseLayer) -> None:
         """Copy data from another layer instance.
@@ -681,7 +682,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             >>> font.copyData(sourceFont)
 
         """
-        super(BaseLayer, self).copyData(source)
+        super().copyData(source)
         for name in source.keys():
             glyph = self.newGlyph(name)
             glyph.copyData(source[name])
@@ -692,7 +693,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -712,13 +713,13 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is None:
             return None
         return self._font()
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None:
             raise AssertionError("font for layer already set")
@@ -752,7 +753,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         """,
     )
 
-    def _get_base_name(self) -> Optional[str]:
+    def _get_base_name(self) -> str | None:
         value = self._get_name()
         if value is not None:
             value = normalizers.normalizeLayerName(value)
@@ -769,7 +770,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
                 raise ValueError(f"A layer with the name '{value}' already exists.")
         self._set_name(value)
 
-    def _get_name(self) -> Optional[str]:  # type: ignore[return]
+    def _get_name(self) -> str | None:  # type: ignore[return]
         """Get the name of the native layer.
 
         This is the environment implementation of the :attr:`BaseLayer.name`
@@ -833,20 +834,20 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         """,
     )
 
-    def _get_base_color(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:
+    def _get_base_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
         return value
 
     def _set_base_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:  # type: ignore[return]
+    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:  # type: ignore[return]
         """Get the color of the layer.
 
         This is the environment implementation of
@@ -866,7 +867,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         self.raiseNotImplementedError()
 
     def _set_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]], **kwargs: Any
+        self, value: QuadrupleCollectionType[IntFloatType] | None, **kwargs: Any
     ) -> None:
         r"""Get or set the color of the layer.
 
@@ -1130,7 +1131,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
     def isCompatible(
         self, other: BaseLayer, cls=None
-    ) -> Tuple[bool, LayerCompatibilityReporter]:
+    ) -> tuple[bool, LayerCompatibilityReporter]:
         """Evaluate interpolation compatibility with another layer.
 
         :param other: The other :class:`BaseLayer` instance to check
@@ -1151,7 +1152,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             [Fatal] The glyphs do not contain the same number of contours.
 
         """
-        return super(BaseLayer, self).isCompatible(other, BaseLayer)
+        return super().isCompatible(other, BaseLayer)
 
     def _isCompatible(
         self, other: BaseLayer, reporter: LayerCompatibilityReporter

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -815,7 +815,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
         The value must be a :class:`tuple` of :class:`int`
         or :class:`float` numbers representing a :ref:`type-color`,
-        or :obj`None` to indicate that the layer does not have an
+        or :obj:`None` to indicate that the layer does not have an
         assigned color.
 
         :return: A :class:`tuple` containing :class:`int`
@@ -851,7 +851,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         This is the environment implementation of
         the :attr:`BaseLayer.color` property getter.
 
-        :return: The :ref:`type-color` assigned to the layer, or :obj`None` to
+        :return: The :ref:`type-color` assigned to the layer, or :obj:`None` to
             indicate that the layer does not have an assigned color. The value
             will be normalized with :func:`normalizers.normalizeColor`.
         :raises NotImplementedError: If the method has not been
@@ -1094,7 +1094,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         This is the environment implementation of :meth:`BaseLayer.interpolate`.
 
         :param factor: The interpolation value as a single :class:`int`
-            or :class:`float` or a :class:`tuple of two :class:`int`
+            or :class:`float` or a :class:`tuple` of two :class:`int`
             or :class:`float` values representing the factors ``(x, y)``.
         :param minLayer: The :class:`BaseLayer` subclass instance
             corresponding to the 0.0 position in the interpolation.

--- a/Lib/fontParts/base/lib.py
+++ b/Lib/fontParts/base/lib.py
@@ -85,9 +85,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             return None
         return self._glyph()
 
-    def _set_glyph(
-        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
-    ) -> None:
+    def _set_glyph(self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None) -> None:
         if self._font is not None:
             raise AssertionError("font for lib already set")
         if self._glyph is not None and self._glyph() != glyph:
@@ -127,9 +125,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             return self.glyph.font
         return None
 
-    def _set_font(
-        self, font: BaseFont | Callable[[], BaseFont] | None
-    ) -> None:
+    def _set_font(self, font: BaseFont | Callable[[], BaseFont] | None) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError("font for lib already set and is not same as font")
         if self._glyph is not None:
@@ -308,9 +304,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """
         super().clear()
 
-    def get(
-        self, key: str, default: LibValueType | None = None
-    ) -> LibValueType | None:
+    def get(self, key: str, default: LibValueType | None = None) -> LibValueType | None:
         """Get the value for the given key in the lib.
 
         If the given `key` is not found, The specified `default` will be returned.
@@ -386,9 +380,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """
         return super().values()
 
-    def pop(
-        self, key: str, default: LibValueType | None = None
-    ) -> LibValueType | None:
+    def pop(self, key: str, default: LibValueType | None = None) -> LibValueType | None:
         """Remove the specified key and return its associated value.
 
         If the `key` does not exist, the `default` value is returned.

--- a/Lib/fontParts/base/lib.py
+++ b/Lib/fontParts/base/lib.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Callable, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from collections.abc import Callable, Iterator
 from collections.abc import MutableMapping
 
 from fontParts.base.base import BaseDict, dynamicProperty, reference
@@ -41,7 +42,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         normalizers.normalizeLibValue
     )
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = []
         if self.glyph is not None:
             contents.append("in glyph")
@@ -57,7 +58,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
 
     # Glyph
 
-    _glyph: Optional[Callable[[], BaseGlyph]] = None
+    _glyph: Callable[[], BaseGlyph] | None = None
 
     glyph: dynamicProperty = dynamicProperty(
         "glyph",
@@ -79,13 +80,13 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._glyph is None:
             return None
         return self._glyph()
 
     def _set_glyph(
-        self, glyph: Optional[Union[BaseGlyph, Callable[[], BaseGlyph]]]
+        self, glyph: BaseGlyph | Callable[[], BaseGlyph] | None
     ) -> None:
         if self._font is not None:
             raise AssertionError("font for lib already set")
@@ -97,7 +98,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
 
     # Font
 
-    _font: Optional[Callable[[], BaseFont]] = None
+    _font: Callable[[], BaseFont] | None = None
 
     font: dynamicProperty = dynamicProperty(
         "font",
@@ -119,7 +120,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._font is not None:
             return self._font()
         elif self._glyph is not None:
@@ -127,7 +128,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         return None
 
     def _set_font(
-        self, font: Optional[Union[BaseFont, Callable[[], BaseFont]]]
+        self, font: BaseFont | Callable[[], BaseFont] | None
     ) -> None:
         if self._font is not None and self._font() != font:
             raise AssertionError("font for lib already set and is not same as font")
@@ -155,7 +156,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._glyph is None:
             return None
         return self.glyph.layer
@@ -180,7 +181,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
         """
         del self[key]
 
-    def asDict(self) -> Dict[str, LibValueType]:
+    def asDict(self) -> dict[str, LibValueType]:
         """Return the lib as a dictionary.
 
         :return A :class:`dict` reflecting the contents of the lib.
@@ -212,7 +213,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             True
 
         """
-        return super(BaseLib, self).__contains__(key)
+        return super().__contains__(key)
 
     def __delitem__(self, key: str) -> None:
         """Remove the given key from the lib.
@@ -224,7 +225,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             >>> del font.lib["public.glyphOrder"]
 
         """
-        super(BaseLib, self).__delitem__(key)
+        super().__delitem__(key)
 
     def __getitem__(self, key: str) -> LibValueType:
         """Get the value associated with the given key.
@@ -249,7 +250,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
                 >>> font.lib["public.glyphOrder"] = lib
 
         """
-        return super(BaseLib, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __iter__(self) -> Iterator[str]:
         """Return an iterator over the keys in the lib.
@@ -267,7 +268,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             "public.postscriptNames"
 
         """
-        return super(BaseLib, self).__iter__()
+        return super().__iter__()
 
     def __len__(self) -> int:
         """Return the number of keys in the lib.
@@ -280,7 +281,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             5
 
         """
-        return super(BaseLib, self).__len__()
+        return super().__len__()
 
     def __setitem__(self, key: str, value: LibValueType) -> None:
         """Set the value for a given key in the lib.
@@ -293,7 +294,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             >>> font.lib["public.glyphOrder"] = ["A", "B", "C"]
 
         """
-        super(BaseLib, self).__setitem__(key, value)
+        super().__setitem__(key, value)
 
     def clear(self) -> None:
         """Remove all keys from the lib.
@@ -305,11 +306,11 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             >>> font.lib.clear()
 
         """
-        super(BaseLib, self).clear()
+        super().clear()
 
     def get(
-        self, key: str, default: Optional[LibValueType] = None
-    ) -> Optional[LibValueType]:
+        self, key: str, default: LibValueType | None = None
+    ) -> LibValueType | None:
         """Get the value for the given key in the lib.
 
         If the given `key` is not found, The specified `default` will be returned.
@@ -338,7 +339,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
                 >>> font.lib["public.glyphOrder"] = lib
 
         """
-        return super(BaseLib, self).get(key, default)
+        return super().get(key, default)
 
     def items(self) -> BaseItems[str, LibValueType]:
         """Return the lib's items.
@@ -356,7 +357,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
              ("public.postscriptNames", {'be': 'uni0431', 'ze': 'uni0437'})]
 
         """
-        return super(BaseLib, self).items()
+        return super().items()
 
     def keys(self) -> BaseKeys[str]:
         """Return the lib's keys.
@@ -370,7 +371,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
              "public.postscriptNames"]
 
         """
-        return super(BaseLib, self).keys()
+        return super().keys()
 
     def values(self) -> BaseValues[LibValueType]:
         """Return the lib's values.
@@ -383,11 +384,11 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             [["A", "B", "C"], {'be': 'uni0431', 'ze': 'uni0437'}]
 
         """
-        return super(BaseLib, self).values()
+        return super().values()
 
     def pop(
-        self, key: str, default: Optional[LibValueType] = None
-    ) -> Optional[LibValueType]:
+        self, key: str, default: LibValueType | None = None
+    ) -> LibValueType | None:
         """Remove the specified key and return its associated value.
 
         If the `key` does not exist, the `default` value is returned.
@@ -404,7 +405,7 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             ["A", "B", "C"]
 
         """
-        return super(BaseLib, self).pop(key, default)
+        return super().pop(key, default)
 
     def update(self, otherLib: MutableMapping[str, LibValueType]) -> None:
         """Update the current lib with key-value pairs from another.
@@ -424,4 +425,4 @@ class BaseLib(BaseDict, DeprecatedLib, RemovedLib):
             >>> font.lib.update(newLib)
 
         """
-        super(BaseLib, self).update(otherLib)
+        super().update(otherLib)

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -39,14 +39,14 @@ if TYPE_CHECKING:
 def normalizeFileFormatVersion(value: int) -> int:
     """Normalize a font's file format version.
 
-    :param value: The file format verison of the font as an :class:`int`.
+    :param value: The file format version of the font as an :class:`int`.
     :return: An :class:`int` representing the normalized file format version.
     :raises TypeError: If `value` is not of type :class:`int`.
 
     """
     if not isinstance(value, int):
         raise TypeError(
-            f"Expected file formmat verison 'value' to be of type int, not {type(value).__name__}."
+            f"Expected file format version 'value' to be of type int, not {type(value).__name__}."
         )
     return value
 
@@ -79,7 +79,7 @@ def normalizeLayerOrder(value: CollectionType[str], font) -> tuple[str, ...]:
         normalization applies.
     :return: A :class:`tuple` of layer names in their normalized order.
     :raises TypeError:
-        - If `value` is not a :class:`list` or :class:`tuple.
+        - If `value` is not a :class:`list` or :class:`tuple`.
         - If any `value` item is not a :class:`str`.
     :raises ValueError:
         - If `value` contains duplicate values.
@@ -135,7 +135,7 @@ def normalizeGlyphOrder(value: CollectionType[str]) -> tuple[str, ...]:
         - must be unique (no duplicates are allowed).
     :return: A :class:`tuple` of glyph names in their normalized order.
     :raises TypeError:
-        - If `value` is not a :class:`list` or :class:`tuple.
+        - If `value` is not a :class:`list` or :class:`tuple`.
         - If any `value` item is not a :class:`str`.
     :raises ValueError:
         - If `value` contains duplicate values.
@@ -169,7 +169,7 @@ def normalizeKerningKey(value: PairCollectionType[str]) -> PairType[str]:
         - must be at least one character long.
     :return: The normalized kerning key as a :class:`tuple` of :class:`str` items.
     :raises TypeError:
-        - If `value` is not a :class:`list` or :class:`tuple.
+        - If `value` is not a :class:`list` or :class:`tuple`.
         - If any `value` item is not a :class:`str`.
     :raises ValueError:
         - If `value` does not a contain a pair of items.
@@ -214,7 +214,7 @@ def normalizeKerningValue(value: IntFloatType) -> IntFloatType:
     """
     if not isinstance(value, (int, float)):
         raise TypeError(
-            f"Kerning value must be a int or a float, not {type(value).__name__}."
+            f"Kerning value must be an int or a float, not {type(value).__name__}."
         )
     return value
 
@@ -285,7 +285,7 @@ def normalizeLibKey(value: str) -> str:
     """Normalize a lib key.
 
     :param value: The lib key to normalize as a non-empty :class:`str`.
-    :return: A :class:`str` representing the noramlized lib key.
+    :return: A :class:`str` representing the normalized lib key.
     :raises TypeError: If `value` is not a :class:`str`.
     :raises ValueError: If `value` is an empty :class:`str`.
 
@@ -415,12 +415,12 @@ def normalizeGlyphUnicodes(value: CollectionType[int]) -> tuple[int, ...]:
         or :class:`tuple` of Unicode values. Each item in `value`:
         - must normalize as glyph unicodes with :func:`normalizeGlyphUnicode`.
         - must be unique (no duplicates are allowed).
-    :return: A :class:`tuple of :class:`int` values representing the noramlized
+    :return: A :class:`tuple` of :class:`int` values representing the normalized
         glyph unicodes.
     :raises TypeError: If `value` is not a :class:`list` or :class:`tuple`.
     :raises ValueError:
         - If `value` contains duplicate values.
-        - If any `value` item is not a valid hexadelimal value.
+        - If any `value` item is not a valid hexadecimal value.
         - If any `value` item is not within the unicode range.
 
     """
@@ -438,10 +438,10 @@ def normalizeGlyphUnicode(value: int | str) -> int:
 
     :param value: The glyph Unicode value to normalize as an :class:`int` or a
         hexadecimal :class:`str`. The value must be within the unicode range.
-    :return: An :class:`int` representing the noramlized unicode value.
+    :return: An :class:`int` representing the normalized unicode value.
     :raises TypeError: If `value` is not and :class:`int` or a :class:`str`.
     :raises ValueError:
-        - If `value` is not a valid hexadelimal value.
+        - If `value` is not a valid hexadecimal value.
         - If `value` is not within the unicode range.
 
     """
@@ -773,7 +773,7 @@ def normalizeComponent(value: BaseComponent) -> BaseComponent:
 def normalizeComponentScale(value: PairCollectionType[IntFloatType]) -> PairType[float]:
     """Normalize a component scale.
 
-    :param value: The component scale to noramlize as a :class:`list`
+    :param value: The component scale to normalize as a :class:`list`
         or :class:`tuple` of two :class:`int` or :class:`float` values.
     :return: A :class:`tuple` of two :class:`float` values representing the
         normalized component scale.
@@ -995,7 +995,7 @@ def normalizeCoordinateTuple(
 ) -> PairType[IntFloatType]:
     """Normalize a coordinate tuple.
 
-    :param value: The coordinate tuple to noramlize as a :class:`list`
+    :param value: The coordinate tuple to normalize as a :class:`list`
         or :class:`tuple` of two :class:`int` or :class:`float` values.
     :return: :return: A :class:`tuple` of two values of the same type as the
          items in `value`, representing the normalized coordinates.
@@ -1113,7 +1113,7 @@ def normalizeColor(
         corresponding to the red, green, blue, and alpha (RGBA) channels, in that
         order.
     :return: A :class:`tuple` of four :class:`float` values representing the
-        noramlized color.
+        normalized color.
     :raises TypeError:
         - If `value` is not a :class:`list` or :class:`tuple`.
         - If any `value` item is not an :class:`int` or a :class:`float`.
@@ -1148,7 +1148,7 @@ def normalizeGlyphNote(value: str) -> str:
     """Normalize a glyph note.
 
     :param value: The glyph note to normalize as a :class:`str`.
-    :return: A :class:`str` representing the noramlized glyph note.
+    :return: A :class:`str` representing the normalized glyph note.
     :raises TypeError if `value` is not a :class:`str`.
 
     """
@@ -1354,7 +1354,7 @@ def normalizeTransformationScale(value: TransformationType) -> PairType[float]:
 def normalizeVisualRounding(value: IntFloatType) -> int:
     """Normalize rounding.
 
-    Python 3 uses banker’s rounding, meaning anything that is at 0.5 will round
+    Python 3 uses banker's rounding, meaning anything that is at 0.5 will round
     to the nearest even number. This isn't always ideal for point coordinates,
     so instead, this function rounds to the higher number
     with :func:`fontTools.misc.roundTools.otRound`.

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -622,7 +622,9 @@ def normalizePointType(value: str) -> str:
         raise TypeError(f"Point type must be a string, not {type(value).__name__}.")
     if value not in allowedTypes:
         raise ValueError(
-            "Point type must be '{}'; not {!r}.".format("', '".join(allowedTypes), value)
+            "Point type must be '{}'; not {!r}.".format(
+                "', '".join(allowedTypes), value
+            )
         )
     return value
 
@@ -699,7 +701,9 @@ def normalizeSegmentType(value: str) -> str:
         raise TypeError(f"Segment type must be a string, not {type(value).__name__}.")
     if value not in allowedTypes:
         raise ValueError(
-            "Segment type must be '{}'; not {!r}.".format("', '".join(allowedTypes), value)
+            "Segment type must be '{}'; not {!r}.".format(
+                "', '".join(allowedTypes), value
+            )
         )
     return value
 

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf8 -*-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Type, Union
@@ -68,7 +67,7 @@ def normalizeFileStructure(value: str) -> str:
     return value
 
 
-def normalizeLayerOrder(value: CollectionType[str], font) -> Tuple[str, ...]:
+def normalizeLayerOrder(value: CollectionType[str], font) -> tuple[str, ...]:
     """Normalize layer order.
 
     :param value: The layer order to normalize as a :class:`list`
@@ -127,7 +126,7 @@ def normalizeDefaultLayerName(value: str, font) -> str:
     return str(value)
 
 
-def normalizeGlyphOrder(value: CollectionType[str]) -> Tuple[str, ...]:
+def normalizeGlyphOrder(value: CollectionType[str]) -> tuple[str, ...]:
     """Normalize glyph order.
 
     :param value: The glyph order to normalize as a :class:`list`
@@ -241,7 +240,7 @@ def normalizeGroupKey(value: str) -> str:
     return value
 
 
-def normalizeGroupValue(value: CollectionType[str]) -> Tuple[str, ...]:
+def normalizeGroupValue(value: CollectionType[str]) -> tuple[str, ...]:
     """Normalize a group value.
 
     :param value: The group value to normalize as a :class:`list`
@@ -409,7 +408,7 @@ def normalizeGlyphName(value: str) -> str:
     return value
 
 
-def normalizeGlyphUnicodes(value: CollectionType[int]) -> Tuple[int, ...]:
+def normalizeGlyphUnicodes(value: CollectionType[int]) -> tuple[int, ...]:
     """Normalize a glyph's unicodes.
 
     :param value: The glyph unicodes to normalize as a :class:`list`
@@ -434,7 +433,7 @@ def normalizeGlyphUnicodes(value: CollectionType[int]) -> Tuple[int, ...]:
     return tuple(values)
 
 
-def normalizeGlyphUnicode(value: Union[int, str]) -> int:
+def normalizeGlyphUnicode(value: int | str) -> int:
     """Normalize a glyph's unicode.
 
     :param value: The glyph Unicode value to normalize as an :class:`int` or a
@@ -475,7 +474,7 @@ def normalizeGlyphWidth(value: IntFloatType) -> IntFloatType:
     return value
 
 
-def normalizeGlyphLeftMargin(value: Optional[IntFloatType]) -> Optional[IntFloatType]:
+def normalizeGlyphLeftMargin(value: IntFloatType | None) -> IntFloatType | None:
     """Normalize a glyph's left margin.
 
     :param value: The glyph left margin to normalize as
@@ -491,7 +490,7 @@ def normalizeGlyphLeftMargin(value: Optional[IntFloatType]) -> Optional[IntFloat
     return value
 
 
-def normalizeGlyphRightMargin(value: Optional[IntFloatType]) -> Optional[IntFloatType]:
+def normalizeGlyphRightMargin(value: IntFloatType | None) -> IntFloatType | None:
     """Normalize a glyph's right margin.
 
     :param value: The glyph right margin to normalize as
@@ -522,7 +521,7 @@ def normalizeGlyphHeight(value: IntFloatType) -> IntFloatType:
     return value
 
 
-def normalizeGlyphBottomMargin(value: Optional[IntFloatType]) -> Optional[IntFloatType]:
+def normalizeGlyphBottomMargin(value: IntFloatType | None) -> IntFloatType | None:
     """Normalize a glyph's bottom margin.
 
     :param value: The glyph bottom margin to normalize as
@@ -538,7 +537,7 @@ def normalizeGlyphBottomMargin(value: Optional[IntFloatType]) -> Optional[IntFlo
     return value
 
 
-def normalizeGlyphTopMargin(value: Optional[IntFloatType]) -> Optional[IntFloatType]:
+def normalizeGlyphTopMargin(value: IntFloatType | None) -> IntFloatType | None:
     """Normalize a glyph's top margin.
 
     :param value: The glyph top margin to normalize as
@@ -623,7 +622,7 @@ def normalizePointType(value: str) -> str:
         raise TypeError(f"Point type must be a string, not {type(value).__name__}.")
     if value not in allowedTypes:
         raise ValueError(
-            "Point type must be '%s'; not %r." % ("', '".join(allowedTypes), value)
+            "Point type must be '{}'; not {!r}.".format("', '".join(allowedTypes), value)
         )
     return value
 
@@ -700,7 +699,7 @@ def normalizeSegmentType(value: str) -> str:
         raise TypeError(f"Segment type must be a string, not {type(value).__name__}.")
     if value not in allowedTypes:
         raise ValueError(
-            "Segment type must be '%s'; not %r." % ("', '".join(allowedTypes), value)
+            "Segment type must be '{}'; not {!r}.".format("', '".join(allowedTypes), value)
         )
     return value
 
@@ -825,7 +824,7 @@ def normalizeAnchorName(value: str) -> str:
     if not isinstance(value, str):
         raise TypeError(f"Anchor names must be strings, not {type(value).__name__}.")
     if len(value) < 1:
-        raise ValueError(("Anchor names must be at least one character long or None."))
+        raise ValueError("Anchor names must be at least one character long or None.")
     return value
 
 
@@ -868,7 +867,7 @@ def normalizeGuidelineName(value: str) -> str:
 # -------
 
 
-def normalizeInternalObjectType(value: object, cls: Type[T], name: str) -> T:
+def normalizeInternalObjectType(value: object, cls: type[T], name: str) -> T:
     """Normalize an internal object type.
 
     :param value: The object instance to normalize.
@@ -904,7 +903,7 @@ def normalizeBoolean(value: int) -> bool:
 # Identification
 
 
-def normalizeIndex(value: Optional[int]) -> Optional[int]:
+def normalizeIndex(value: int | None) -> int | None:
     """Normalize an index.
 
     :param value: The index to normalize as an :class:`int`, or :obj:`None`.
@@ -920,7 +919,7 @@ def normalizeIndex(value: Optional[int]) -> Optional[int]:
     return value
 
 
-def normalizeIdentifier(value: Optional[str]) -> Optional[str]:
+def normalizeIdentifier(value: str | None) -> str | None:
     """Normalize an identifier.
 
     :param value: The identifier to normalize as a non-empty :class:`str`,
@@ -1157,7 +1156,7 @@ def normalizeGlyphNote(value: str) -> str:
 # File Path
 
 
-def normalizeFilePath(value: Union[str, Path]) -> str:
+def normalizeFilePath(value: str | Path) -> str:
     """Normalize a file path.
 
     :param value: The file path to normalize as a :class:`str` or :class:`pathlib.Path`.

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Union, Tuple
+from collections.abc import Callable
 
 from fontTools.misc import transform
 from fontParts.base.base import (
@@ -63,7 +64,7 @@ class BasePoint(
 
     # Contour
 
-    _contour: Optional[Callable[[], BaseContour]] = None
+    _contour: Callable[[], BaseContour] | None = None
 
     contour: dynamicProperty = dynamicProperty(
         "contour",
@@ -83,13 +84,13 @@ class BasePoint(
         """,
     )
 
-    def _get_contour(self) -> Optional[BaseContour]:
+    def _get_contour(self) -> BaseContour | None:
         if self._contour is None:
             return None
         return self._contour()
 
     def _set_contour(
-        self, contour: Optional[Union[BaseContour, Callable[[], BaseContour]]]
+        self, contour: BaseContour | Callable[[], BaseContour] | None
     ) -> None:
         if self._contour is not None:
             raise AssertionError("contour for point already set")
@@ -117,7 +118,7 @@ class BasePoint(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseObject]:
+    def _get_glyph(self) -> BaseObject | None:
         if self._contour is None:
             return None
         return self.contour.glyph
@@ -140,7 +141,7 @@ class BasePoint(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseObject]:
+    def _get_layer(self) -> BaseObject | None:
         if self._contour is None:
             return None
         return self.glyph.layer
@@ -163,7 +164,7 @@ class BasePoint(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseObject]:
+    def _get_font(self) -> BaseObject | None:
         if self._contour is None:
             return None
         return self.glyph.font
@@ -467,12 +468,12 @@ class BasePoint(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         value = self._get_index()
         value = normalizers.normalizeIndex(value)
         return value
 
-    def _get_index(self) -> Optional[int]:
+    def _get_index(self) -> int | None:
         """Get the index of the native point.
 
         This is the environment implementation of the :attr:`BasePoint.index`
@@ -512,7 +513,7 @@ class BasePoint(
         """,
     )
 
-    def _get_base_name(self) -> Optional[str]:
+    def _get_base_name(self) -> str | None:
         value = self._get_name()
         if value is not None:
             value = normalizers.normalizePointName(value)
@@ -523,7 +524,7 @@ class BasePoint(
             value = normalizers.normalizePointName(value)
         self._set_name(value)
 
-    def _get_name(self) -> Optional[str]:  # type: ignore[return]
+    def _get_name(self) -> str | None:  # type: ignore[return]
         """Get the name of the native point.
 
         This is the environment implementation of the :attr:`BasePoint.name`

--- a/Lib/fontParts/base/segment.py
+++ b/Lib/fontParts/base/segment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Callable, Generator, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from collections.abc import Callable, Generator
 
 from fontParts.base.errors import FontPartsError
 from fontParts.base.base import (
@@ -42,7 +43,7 @@ class BaseSegment(
             raise AssertionError("segment has points")
         self._points = points
 
-    def _reprContents(self) -> List[str]:
+    def _reprContents(self) -> list[str]:
         contents = [f"{self.type}"]
         if self.index is not None:
             contents.append(f"index='{self.index!r}'")
@@ -59,7 +60,7 @@ class BaseSegment(
 
     # Contour
 
-    _contour: Optional[Callable[[], BaseContour]] = None
+    _contour: Callable[[], BaseContour] | None = None
 
     contour: dynamicProperty = dynamicProperty(
         "contour",
@@ -79,13 +80,13 @@ class BaseSegment(
         """,
     )
 
-    def _get_contour(self) -> Optional[BaseContour]:
+    def _get_contour(self) -> BaseContour | None:
         if self._contour is None:
             return None
         return self._contour()
 
     def _set_contour(
-        self, contour: Optional[Union[BaseContour, Callable[[], BaseContour]]]
+        self, contour: BaseContour | Callable[[], BaseContour] | None
     ) -> None:
         if self._contour is not None:
             raise AssertionError("contour for segment already set")
@@ -113,7 +114,7 @@ class BaseSegment(
         """,
     )
 
-    def _get_glyph(self) -> Optional[BaseGlyph]:
+    def _get_glyph(self) -> BaseGlyph | None:
         if self._contour is None:
             return None
         return self.contour.glyph
@@ -136,7 +137,7 @@ class BaseSegment(
         """,
     )
 
-    def _get_layer(self) -> Optional[BaseLayer]:
+    def _get_layer(self) -> BaseLayer | None:
         if self._contour is None:
             return None
         return self.glyph.layer
@@ -159,7 +160,7 @@ class BaseSegment(
         """,
     )
 
-    def _get_font(self) -> Optional[BaseFont]:
+    def _get_font(self) -> BaseFont | None:
         if self._contour is None:
             return None
         return self.glyph.font
@@ -212,7 +213,7 @@ class BaseSegment(
         """,
     )
 
-    def _get_base_index(self) -> Optional[int]:
+    def _get_base_index(self) -> int | None:
         if self.contour is None:
             return None
         value = self._get_index()
@@ -503,10 +504,10 @@ class BaseSegment(
         """,
     )
 
-    def _get_base_points(self) -> Tuple[BasePoint, ...]:
+    def _get_base_points(self) -> tuple[BasePoint, ...]:
         return self._get_points()
 
-    def _get_points(self) -> Tuple[BasePoint, ...]:
+    def _get_points(self) -> tuple[BasePoint, ...]:
         """Get a list of all points in the native segment.
 
         This is the environment implementation of the :attr:`BaseSegment.points`
@@ -534,10 +535,10 @@ class BaseSegment(
         """,
     )
 
-    def _get_base_onCurve(self) -> Optional[BasePoint]:
+    def _get_base_onCurve(self) -> BasePoint | None:
         return self._get_onCurve()
 
-    def _get_onCurve(self) -> Optional[BasePoint]:
+    def _get_onCurve(self) -> BasePoint | None:
         """Get the on-curve point in the native segment.
 
         This is the environment implementation of
@@ -566,10 +567,10 @@ class BaseSegment(
         """,
     )
 
-    def _get_base_offCurve(self) -> Tuple[BasePoint, ...]:
+    def _get_base_offCurve(self) -> tuple[BasePoint, ...]:
         return self._get_offCurve()
 
-    def _get_offCurve(self) -> Tuple[BasePoint, ...]:
+    def _get_offCurve(self) -> tuple[BasePoint, ...]:
         """Get the off-curve points in the native segment.
 
         This is the environment implementation of
@@ -615,7 +616,7 @@ class BaseSegment(
 
     def isCompatible(
         self, other: BaseSegment, cls=None
-    ) -> Tuple[bool, SegmentCompatibilityReporter]:
+    ) -> tuple[bool, SegmentCompatibilityReporter]:
         """Evaluate interpolation compatibility with another segment.
 
         This method will return a :class:`bool` indicating if the segment is
@@ -641,7 +642,7 @@ class BaseSegment(
             [Fatal] Segment: [1] is line | [1] is qcurve
 
         """
-        return super(BaseSegment, self).isCompatible(other, BaseSegment)
+        return super().isCompatible(other, BaseSegment)
 
     def _isCompatible(
         self, other: BaseSegment, reporter: SegmentCompatibilityReporter
@@ -664,7 +665,7 @@ class BaseSegment(
         # type
         if segment1.type != segment2.type:
             # line <-> curve can be converted
-            if set((segment1.type, segment2.type)) != set(("curve", "line")):
+            if {segment1.type, segment2.type} != {"curve", "line"}:
                 reporter.typeDifference = True
                 reporter.fatal = True
 

--- a/Lib/fontParts/fontshell/anchor.py
+++ b/Lib/fontParts/fontshell/anchor.py
@@ -14,13 +14,13 @@ from fontParts.fontshell.base import RBaseObject
 class RAnchor(RBaseObject, BaseAnchor):
     wrapClass = defcon.Anchor
 
-    def _init(self, pathOrObject: Optional[defcon.Anchor] = None) -> None:
+    def _init(self, pathOrObject: defcon.Anchor | None = None) -> None:
         if self.wrapClass is not None:
             if pathOrObject is None:
                 pathOrObject = self.wrapClass()
                 pathOrObject.x = 0
                 pathOrObject.y = 0
-            super(RAnchor, self)._init(pathOrObject=pathOrObject)
+            super()._init(pathOrObject=pathOrObject)
 
     # --------
     # Position
@@ -48,7 +48,7 @@ class RAnchor(RBaseObject, BaseAnchor):
 
     # identifier
 
-    def _get_identifier(self) -> Optional[str]:
+    def _get_identifier(self) -> str | None:
         return self.naked().identifier
 
     def _getIdentifier(self) -> str:
@@ -59,21 +59,21 @@ class RAnchor(RBaseObject, BaseAnchor):
 
     # name
 
-    def _get_name(self) -> Optional[str]:
+    def _get_name(self) -> str | None:
         return self.naked().name
 
-    def _set_name(self, value: Optional[str]) -> None:
+    def _set_name(self, value: str | None) -> None:
         self.naked().name = value
 
     # color
 
-    def _get_color(self) -> Optional[QuadrupleType[float]]:
+    def _get_color(self) -> QuadrupleType[float] | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/anchor.py
+++ b/Lib/fontParts/fontshell/anchor.py
@@ -73,7 +73,5 @@ class RAnchor(RBaseObject, BaseAnchor):
             value = tuple(value)
         return value
 
-    def _set_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
-    ) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/base.py
+++ b/Lib/fontParts/fontshell/base.py
@@ -5,10 +5,10 @@ RBaseObjectType = TypeVar("RBaseObjectType", bound="RBaseObject")
 
 
 class RBaseObject(Generic[RBaseObjectType]):
-    wrapClass: Optional[Type[RBaseObjectType]] = None
+    wrapClass: type[RBaseObjectType] | None = None
     dirty: bool
 
-    def _init(self, pathOrObject: Optional[RBaseObjectType] = None) -> None:
+    def _init(self, pathOrObject: RBaseObjectType | None = None) -> None:
         if pathOrObject is None and self.wrapClass is not None:
             pathOrObject = self.wrapClass()  # pylint: disable=E1102
         if pathOrObject is not None:

--- a/Lib/fontParts/fontshell/component.py
+++ b/Lib/fontParts/fontshell/component.py
@@ -12,7 +12,7 @@ from fontParts.fontshell.base import RBaseObject
 
 
 class RComponent(RBaseObject, BaseComponent):
-    wrapClass: Type[defcon.Component] = defcon.Component
+    wrapClass: type[defcon.Component] = defcon.Component
 
     # ----------
     # Attributes
@@ -20,7 +20,7 @@ class RComponent(RBaseObject, BaseComponent):
 
     # baseGlyph
 
-    def _get_baseGlyph(self) -> Optional[str]:
+    def _get_baseGlyph(self) -> str | None:
         component = self.naked()
         return component.baseGlyph if component else None
 

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -34,7 +34,7 @@ class RContour(RBaseObject, BaseContour):
 
     # identifier
 
-    def _get_identifier(self) -> Optional[str]:
+    def _get_identifier(self) -> str | None:
         return self.naked().identifier
 
     def _getIdentifier(self) -> str:
@@ -56,14 +56,14 @@ class RContour(RBaseObject, BaseContour):
     # Bounds
     # ------
 
-    def _get_bounds(self) -> Optional[QuadrupleType[float]]:
+    def _get_bounds(self) -> QuadrupleType[float] | None:
         return self.naked().bounds
 
     # ----
     # Area
     # ----
 
-    def _get_area(self) -> Optional[float]:
+    def _get_area(self) -> float | None:
         return self.naked().area
 
     # ---------
@@ -102,10 +102,10 @@ class RContour(RBaseObject, BaseContour):
         self,
         index: int,
         position: PairCollectionType[IntFloatType],
-        type: Optional[str] = None,
-        smooth: Optional[bool] = None,
-        name: Optional[str] = None,
-        identifier: Optional[str] = None,
+        type: str | None = None,
+        smooth: bool | None = None,
+        name: str | None = None,
+        identifier: str | None = None,
         **kwargs: Any,
     ) -> None:
         point = self.pointClass()

--- a/Lib/fontParts/fontshell/features.py
+++ b/Lib/fontParts/fontshell/features.py
@@ -9,10 +9,10 @@ from fontParts.fontshell.base import RBaseObject
 class RFeatures(RBaseObject, BaseFeatures):
     wrapClass = defcon.Features
 
-    def _get_text(self) -> Optional[str]:
+    def _get_text(self) -> str | None:
         features = self.naked()
         return features.text
 
-    def _set_text(self, value: Optional[str]) -> None:
+    def _set_text(self, value: str | None) -> None:
         features = self.naked()
         features.text = value

--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -38,7 +38,7 @@ class RFont(RBaseObject, BaseFont):
 
     def _init(
         self,
-        pathOrObject: Optional[Union[str, os.PathLike, defcon.Font]] = None,
+        pathOrObject: str | os.PathLike | defcon.Font | None = None,
         showInterface: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -53,17 +53,17 @@ class RFont(RBaseObject, BaseFont):
 
     # path
 
-    def _get_path(self, **kwargs: Any) -> Optional[str]:
+    def _get_path(self, **kwargs: Any) -> str | None:
         return self.naked().path
 
     # save
 
     def _save(
         self,
-        path: Optional[str] = None,
+        path: str | None = None,
         showProgress: bool = False,
-        formatVersion: Optional[int] = None,
-        fileStructure: Optional[str] = None,
+        formatVersion: int | None = None,
+        fileStructure: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.naked().save(
@@ -113,14 +113,14 @@ class RFont(RBaseObject, BaseFont):
     # Layers
     # ------
 
-    def _get_layers(self, **kwargs: Any) -> Tuple[RLayer, ...]:
+    def _get_layers(self, **kwargs: Any) -> tuple[RLayer, ...]:
         return tuple(
             self.layerClass(pathOrObject=layer) for layer in self.naked().layers
         )
 
     # order
 
-    def _get_layerOrder(self, **kwargs: Any) -> Tuple[str, ...]:
+    def _get_layerOrder(self, **kwargs: Any) -> tuple[str, ...]:
         return self.naked().layers.layerOrder
 
     def _set_layerOrder(self, value: CollectionType[str], **kwargs: Any) -> None:
@@ -144,7 +144,7 @@ class RFont(RBaseObject, BaseFont):
     def _newLayer(
         self,
         name: str,
-        color: Optional[QuadrupleCollectionType[IntFloatType]],
+        color: QuadrupleCollectionType[IntFloatType] | None,
         **kwargs: Any,
     ) -> RLayer:
         layers = self.naked().layers
@@ -162,7 +162,7 @@ class RFont(RBaseObject, BaseFont):
     # Glyphs
     # ------
 
-    def _get_glyphOrder(self) -> Tuple[str, ...]:
+    def _get_glyphOrder(self) -> tuple[str, ...]:
         return self.naked().glyphOrder
 
     def _set_glyphOrder(self, value: CollectionType[str]) -> None:
@@ -182,10 +182,10 @@ class RFont(RBaseObject, BaseFont):
     def _appendGuideline(
         self,
         position: PairCollectionType[IntFloatType],
-        angle: Optional[float],
-        name: Optional[str] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        identifier: Optional[str] = None,
+        angle: float | None,
+        name: str | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        identifier: str | None = None,
         **kwargs: Any,
     ) -> RGuideline:
         font = self.naked()

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -76,13 +76,13 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _set_width(self, value: IntFloatType) -> None:
         self.naked().width = value
 
-    def _get_leftMargin(self) -> Optional[IntFloatType]:
+    def _get_leftMargin(self) -> IntFloatType | None:
         return self.naked().leftMargin
 
     def _set_leftMargin(self, value: IntFloatType) -> None:
         self.naked().leftMargin = value
 
-    def _get_rightMargin(self) -> Optional[IntFloatType]:
+    def _get_rightMargin(self) -> IntFloatType | None:
         return self.naked().rightMargin
 
     def _set_rightMargin(self, value: IntFloatType) -> None:
@@ -96,13 +96,13 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _set_height(self, value: IntFloatType) -> None:
         self.naked().height = value
 
-    def _get_bottomMargin(self) -> Optional[IntFloatType]:
+    def _get_bottomMargin(self) -> IntFloatType | None:
         return self.naked().bottomMargin
 
     def _set_bottomMargin(self, value: IntFloatType) -> None:
         self.naked().bottomMargin = value
 
-    def _get_topMargin(self) -> Optional[IntFloatType]:
+    def _get_topMargin(self) -> IntFloatType | None:
         return self.naked().topMargin
 
     def _set_topMargin(self, value: IntFloatType) -> None:
@@ -112,14 +112,14 @@ class RGlyph(RBaseObject, BaseGlyph):
     # Bounds
     # ------
 
-    def _get_bounds(self) -> Optional[QuadrupleType[IntFloatType]]:
+    def _get_bounds(self) -> QuadrupleType[IntFloatType] | None:
         return self.naked().bounds
 
     # ----
     # Area
     # ----
 
-    def _get_area(self) -> Optional[float]:
+    def _get_area(self) -> float | None:
         return self.naked().area
 
     # ----
@@ -129,7 +129,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     def getPen(self) -> SegmentToPointPen:
         return self.naked().getPen()
 
-    def getPointPen(self) -> Union[GlyphObjectPointPen, GlyphObjectLoadingPointPen]:
+    def getPointPen(self) -> GlyphObjectPointPen | GlyphObjectLoadingPointPen:
         return self.naked().getPointPen()
 
     # -----------------------------------------
@@ -195,9 +195,9 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _appendAnchor(
         self,
         name: str,
-        position: Optional[PairCollectionType[IntFloatType]] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        identifier: Optional[str] = None,
+        position: PairCollectionType[IntFloatType] | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        identifier: str | None = None,
         **kwargs: Any,
     ) -> RAnchor:
         glyph = self.naked()
@@ -231,11 +231,11 @@ class RGlyph(RBaseObject, BaseGlyph):
 
     def _appendGuideline(
         self,
-        position: Optional[PairCollectionType[IntFloatType]],
+        position: PairCollectionType[IntFloatType] | None,
         angle: float,
-        name: Optional[str] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
-        identifier: Optional[str] = None,
+        name: str | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        identifier: str | None = None,
         **kwargs: Any,
     ) -> RGuideline:
         glyph = self.naked()
@@ -287,7 +287,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     # Image
     # -----
 
-    def _get_image(self) -> Optional[RImage]:
+    def _get_image(self) -> RImage | None:
         image = self.naked().image
         if image is None:
             return None
@@ -296,8 +296,8 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _addImage(
         self,
         data: bytes,
-        transformation: Optional[SextupleCollectionType[IntFloatType]] = None,
-        color: Optional[QuadrupleCollectionType[IntFloatType]] = None,
+        transformation: SextupleCollectionType[IntFloatType] | None = None,
+        color: QuadrupleCollectionType[IntFloatType] | None = None,
     ) -> RImage:
         image = self.naked().image
         image = self.imageClass(image)
@@ -316,23 +316,23 @@ class RGlyph(RBaseObject, BaseGlyph):
 
     # Mark
 
-    def _get_markColor(self) -> Optional[QuadrupleType[float]]:
+    def _get_markColor(self) -> QuadrupleType[float] | None:
         value = self.naked().markColor
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_markColor(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         self.naked().markColor = value
 
     # Note
 
-    def _get_note(self) -> Optional[str]:
+    def _get_note(self) -> str | None:
         return self.naked().note
 
-    def _set_note(self, value: Optional[str]) -> None:
+    def _set_note(self, value: str | None) -> None:
         self.naked().note = value
 
     # -----------

--- a/Lib/fontParts/fontshell/groups.py
+++ b/Lib/fontParts/fontshell/groups.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
-from typing import Tuple, Dict, ItemsView
+from typing import Tuple, Dict
+from collections.abc import ItemsView
 
 import defcon
 from fontParts.base import BaseGroups
 from fontParts.base.annotations import CollectionType
 from fontParts.fontshell.base import RBaseObject
 
-ValueType = Tuple[str, ...]
-GroupsDict = Dict[str, ValueType]
+ValueType = tuple[str, ...]
+GroupsDict = dict[str, ValueType]
 
 
 class RGroups(RBaseObject, BaseGroups):
@@ -23,7 +24,7 @@ class RGroups(RBaseObject, BaseGroups):
         representation = groups.getRepresentation("defcon.groups.kerningSide2Groups")
         return {k: tuple(v) for k, v in representation.items()}
 
-    def _items(self) -> ItemsView[str, Tuple[str]]:
+    def _items(self) -> ItemsView[str, tuple[str]]:
         groups = self.naked()
         formatted = {k: tuple(v) for k, v in groups.items()}
         return formatted.items()
@@ -36,7 +37,7 @@ class RGroups(RBaseObject, BaseGroups):
         groups = self.naked()
         groups[key] = tuple(value)
 
-    def _getItem(self, key: str) -> Tuple[str]:
+    def _getItem(self, key: str) -> tuple[str]:
         groups = self.naked()
         return tuple(groups[key])
 

--- a/Lib/fontParts/fontshell/guideline.py
+++ b/Lib/fontParts/fontshell/guideline.py
@@ -83,7 +83,5 @@ class RGuideline(RBaseObject, BaseGuideline):
             value = tuple(value)
         return value
 
-    def _set_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
-    ) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/guideline.py
+++ b/Lib/fontParts/fontshell/guideline.py
@@ -14,7 +14,7 @@ from fontParts.fontshell.base import RBaseObject
 class RGuideline(RBaseObject, BaseGuideline):
     wrapClass = defcon.Guideline
 
-    def _init(self, pathOrObject: Optional[defcon.Guideline] = None) -> None:
+    def _init(self, pathOrObject: defcon.Guideline | None = None) -> None:
         if self.wrapClass is not None:
             if pathOrObject is None:
                 pathOrObject = self.wrapClass()
@@ -22,7 +22,7 @@ class RGuideline(RBaseObject, BaseGuideline):
                     pathOrObject.x = 0
                     pathOrObject.y = 0
                     pathOrObject.angle = 0
-            super(RGuideline, self)._init(pathOrObject=pathOrObject)
+            super()._init(pathOrObject=pathOrObject)
 
     # --------
     # Position
@@ -49,7 +49,7 @@ class RGuideline(RBaseObject, BaseGuideline):
     def _get_angle(self) -> float:
         return self.naked().angle
 
-    def _set_angle(self, value: Optional[IntFloatType]) -> None:
+    def _set_angle(self, value: IntFloatType | None) -> None:
         self.naked().angle = value
 
     # --------------
@@ -58,7 +58,7 @@ class RGuideline(RBaseObject, BaseGuideline):
 
     # identifier
 
-    def _get_identifier(self) -> Optional[str]:
+    def _get_identifier(self) -> str | None:
         return self.naked().identifier
 
     def _getIdentifier(self) -> str:
@@ -69,21 +69,21 @@ class RGuideline(RBaseObject, BaseGuideline):
 
     # name
 
-    def _get_name(self) -> Optional[str]:
+    def _get_name(self) -> str | None:
         return self.naked().name
 
-    def _set_name(self, value: Optional[str]) -> None:
+    def _set_name(self, value: str | None) -> None:
         self.naked().name = value
 
     # color
 
-    def _get_color(self) -> Optional[QuadrupleType[float]]:
+    def _get_color(self) -> QuadrupleType[float] | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/image.py
+++ b/Lib/fontParts/fontshell/image.py
@@ -16,8 +16,8 @@ from fontParts.fontshell.base import RBaseObject
 
 class RImage(RBaseObject, BaseImage):
     wrapClass = defcon.Image
-    _orphanData: Optional[bytes] = None
-    _orphanColor: Optional[QuadrupleCollectionType[IntFloatType]] = None
+    _orphanData: bytes | None = None
+    _orphanColor: QuadrupleCollectionType[IntFloatType] | None = None
 
     # ----------
     # Attributes
@@ -33,7 +33,7 @@ class RImage(RBaseObject, BaseImage):
 
     # Color
 
-    def _get_color(self) -> Optional[QuadrupleType[float]]:
+    def _get_color(self) -> QuadrupleType[float] | None:
         if self.font is None and self._orphanColor is not None:
             r, g, b, a = self._orphanColor
             return (r, g, b, a)
@@ -43,7 +43,7 @@ class RImage(RBaseObject, BaseImage):
         return value
 
     def _set_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]]
+        self, value: QuadrupleCollectionType[IntFloatType] | None
     ) -> None:
         if self.font is None:
             self._orphanColor = value
@@ -52,7 +52,7 @@ class RImage(RBaseObject, BaseImage):
 
     # Data
 
-    def _get_data(self) -> Optional[bytes]:
+    def _get_data(self) -> bytes | None:
         if self.font is None:
             return self._orphanData
         image = self.naked()

--- a/Lib/fontParts/fontshell/image.py
+++ b/Lib/fontParts/fontshell/image.py
@@ -42,9 +42,7 @@ class RImage(RBaseObject, BaseImage):
             value = tuple(value)
         return value
 
-    def _set_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
-    ) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         if self.font is None:
             self._orphanColor = value
         else:

--- a/Lib/fontParts/fontshell/kerning.py
+++ b/Lib/fontParts/fontshell/kerning.py
@@ -27,6 +27,6 @@ class RKerning(RBaseObject, BaseKerning):
         del self.naked()[key]
 
     def _find(
-        self, pair: PairCollectionType[str], default: Optional[Union[int, float]] = 0
+        self, pair: PairCollectionType[str], default: int | float | None = 0
     ) -> int:
         return self.naked().find(pair, default)

--- a/Lib/fontParts/fontshell/layer.py
+++ b/Lib/fontParts/fontshell/layer.py
@@ -45,14 +45,14 @@ class RLayer(RBaseObject, BaseLayer):
 
     # color
 
-    def _get_color(self) -> Optional[QuadrupleCollectionType[IntFloatType]]:
+    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_color(
-        self, value: Optional[QuadrupleCollectionType[IntFloatType]], **kwargs: Any
+        self, value: QuadrupleCollectionType[IntFloatType] | None, **kwargs: Any
     ) -> None:
         self.naked().color = value
 
@@ -65,7 +65,7 @@ class RLayer(RBaseObject, BaseLayer):
         glyph = layer[name]
         return self.glyphClass(glyph)
 
-    def _keys(self, **kwargs: Any) -> Tuple[str, ...]:
+    def _keys(self, **kwargs: Any) -> tuple[str, ...]:
         return tuple(self.naked().keys())
 
     def _newGlyph(self, name: str, **kwargs: Any) -> BaseGlyph:
@@ -81,10 +81,10 @@ class RLayer(RBaseObject, BaseLayer):
     # mapping
     # -------
 
-    def _getReverseComponentMapping(self) -> Dict[str, Tuple[str, ...]]:
+    def _getReverseComponentMapping(self) -> dict[str, tuple[str, ...]]:
         mapping = self.naked().componentReferences
         return {k: tuple(v) for k, v in mapping.items()}
 
-    def _getCharacterMapping(self) -> Dict[int, Tuple[str, ...]]:
+    def _getCharacterMapping(self) -> dict[int, tuple[str, ...]]:
         mapping = self.naked().unicodeData
         return {k: tuple(v) for k, v in mapping.items()}

--- a/Lib/fontParts/fontshell/point.py
+++ b/Lib/fontParts/fontshell/point.py
@@ -11,10 +11,10 @@ from fontParts.fontshell.base import RBaseObject
 class RPoint(RBaseObject, BasePoint):
     wrapClass = defcon.Point
 
-    def _init(self, pathOrObject: Optional[defcon.Point] = None) -> None:
+    def _init(self, pathOrObject: defcon.Point | None = None) -> None:
         if pathOrObject is None and self.wrapClass is not None:
             pathOrObject = self.wrapClass((0, 0))
-        super(RPoint, self)._init(pathOrObject=pathOrObject)
+        super()._init(pathOrObject=pathOrObject)
 
     def _postChangeNotification(self) -> None:
         contour = self.contour
@@ -75,7 +75,7 @@ class RPoint(RBaseObject, BasePoint):
 
     # name
 
-    def _get_name(self) -> Optional[str]:
+    def _get_name(self) -> str | None:
         return self.naked().name
 
     def _set_name(self, value: str) -> None:
@@ -84,7 +84,7 @@ class RPoint(RBaseObject, BasePoint):
 
     # identifier
 
-    def _get_identifier(self) -> Optional[str]:
+    def _get_identifier(self) -> str | None:
         return self.naked().identifier
 
     def _getIdentifier(self) -> str:
@@ -98,10 +98,8 @@ class RPoint(RBaseObject, BasePoint):
             value = point.identifier
         else:
             raise FontPartsError(
-                (
                     "An identifier can not be generated "
                     "for this point because it does not "
                     "belong to a contour."
-                )
             )
         return value

--- a/Lib/fontParts/fontshell/point.py
+++ b/Lib/fontParts/fontshell/point.py
@@ -98,8 +98,8 @@ class RPoint(RBaseObject, BasePoint):
             value = point.identifier
         else:
             raise FontPartsError(
-                    "An identifier can not be generated "
-                    "for this point because it does not "
-                    "belong to a contour."
+                "An identifier can not be generated "
+                "for this point because it does not "
+                "belong to a contour."
             )
         return value

--- a/Lib/fontParts/test/__init__.py
+++ b/Lib/fontParts/test/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import unittest
 from fontParts.test import test_normalizers

--- a/Lib/fontParts/test/legacyPointPen.py
+++ b/Lib/fontParts/test/legacyPointPen.py
@@ -8,15 +8,15 @@ class LegacyPointPen(RecordingPointPen):
     """
 
     def beginPath(self):
-        super(LegacyPointPen, self).beginPath()
+        super().beginPath()
 
     def endPath(self):
-        super(LegacyPointPen, self).endPath()
+        super().endPath()
 
     def addPoint(self, pt, segmentType=None, smooth=False, name=None):
-        super(LegacyPointPen, self).addPoint(
+        super().addPoint(
             pt, segmentType=segmentType, smooth=smooth, name=name
         )
 
     def addComponent(self, baseGlyphName, transformation):
-        super(LegacyPointPen, self).addComponent(baseGlyphName, transformation)
+        super().addComponent(baseGlyphName, transformation)

--- a/Lib/fontParts/test/legacyPointPen.py
+++ b/Lib/fontParts/test/legacyPointPen.py
@@ -14,9 +14,7 @@ class LegacyPointPen(RecordingPointPen):
         super().endPath()
 
     def addPoint(self, pt, segmentType=None, smooth=False, name=None):
-        super().addPoint(
-            pt, segmentType=segmentType, smooth=smooth, name=name
-        )
+        super().addPoint(pt, segmentType=segmentType, smooth=smooth, name=name)
 
     def addComponent(self, baseGlyphName, transformation):
         super().addComponent(baseGlyphName, transformation)

--- a/Lib/fontParts/test/test_anchor.py
+++ b/Lib/fontParts/test/test_anchor.py
@@ -372,7 +372,7 @@ class TestAnchor(unittest.TestCase):
 
     def test_scaleBy_valid_one_value_no_origin(self):
         anchor = self.getAnchor_generic()
-        anchor.scaleBy((-2))
+        anchor.scaleBy(-2)
         self.assertEqual(anchor.x, -2)
         self.assertEqual(anchor.y, -4)
 

--- a/Lib/fontParts/test/test_bPoint.py
+++ b/Lib/fontParts/test/test_bPoint.py
@@ -761,7 +761,7 @@ class TestBPoint(unittest.TestCase):
 
     def test_scaleBy_valid_one_value_no_origin_anchor(self):
         bPoint = self.getBPoint_curve()
-        bPoint.scaleBy((-2))
+        bPoint.scaleBy(-2)
         self.assertEqual(bPoint.anchor, (-202.0, -404.0))
 
     def test_scaleBy_valid_two_values_no_origin_anchor(self):

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -481,7 +481,7 @@ class TestComponent(unittest.TestCase):
 
     def test_scaleBy_valid_one_value_no_origin(self):
         component = self.getComponent_transform()
-        component.scaleBy((-2))
+        component.scaleBy(-2)
         self.assertEqual(
             component.transformation, (-2.0, -4.0, -6.0, -8.0, -10.0, -12.0)
         )

--- a/Lib/fontParts/test/test_deprecated.py
+++ b/Lib/fontParts/test/test_deprecated.py
@@ -200,9 +200,9 @@ class TestDeprecated(unittest.TestCase):
         anchor1 = self.getAnchor()
         anchor2 = self.getAnchor()
         with self.assertWarnsRegex(DeprecationWarning, "Anchor.scale()"):
-            anchor1.scale((-2))
+            anchor1.scale(-2)
         self.assertNotEqual((anchor1.x, anchor1.y), (anchor2.x, anchor2.y))
-        anchor2.scaleBy((-2))
+        anchor2.scaleBy(-2)
         self.assertEqual((anchor1.x, anchor1.y), (anchor2.x, anchor2.y))
 
     def test_anchor_deprecated_scale_center(self):
@@ -676,7 +676,7 @@ class TestDeprecated(unittest.TestCase):
     def test_guideline_deprecated_scale_no_center(self):
         guideline = self.getGuideline_transform()
         with self.assertWarnsRegex(DeprecationWarning, "Guideline.scale()"):
-            guideline.scale((-2))
+            guideline.scale(-2)
         self.assertEqual(guideline.x, -2)
         self.assertEqual(guideline.y, -4)
         self.assertAlmostEqual(guideline.angle, 225.000, places=3)
@@ -896,9 +896,9 @@ class TestDeprecated(unittest.TestCase):
         glyph1 = self.getGlyph_generic()
         glyph2 = self.getGlyph_generic()
         with self.assertWarnsRegex(DeprecationWarning, "Glyph.scale()"):
-            glyph1.scale((-2))
+            glyph1.scale(-2)
         self.assertNotEqual(glyph1.bounds, glyph2.bounds)
-        glyph2.scaleBy((-2))
+        glyph2.scaleBy(-2)
         self.assertEqual(glyph1.bounds, glyph2.bounds)
 
     def test_glyph_deprecated_scale_center(self):
@@ -1083,9 +1083,9 @@ class TestDeprecated(unittest.TestCase):
         contour1 = self.getContour_bounds()
         contour2 = self.getContour_bounds()
         with self.assertWarnsRegex(DeprecationWarning, "Contour.scale()"):
-            contour1.scale((-2))
+            contour1.scale(-2)
         self.assertNotEqual(contour1.bounds, contour2.bounds)
-        contour2.scaleBy((-2))
+        contour2.scaleBy(-2)
         self.assertEqual(contour1.bounds, contour2.bounds)
 
     def test_contour_deprecated_scale_center(self):
@@ -1233,11 +1233,11 @@ class TestDeprecated(unittest.TestCase):
         segment1 = self.getSegment()
         segment2 = self.getSegment()
         with self.assertWarnsRegex(DeprecationWarning, "Segment.scale()"):
-            segment1.scale((-2))
+            segment1.scale(-2)
         coordinates1 = tuple((point.x, point.y) for point in segment1.points)
         coordinates2 = tuple((point.x, point.y) for point in segment2.points)
         self.assertNotEqual(coordinates1, coordinates2)
-        segment2.scaleBy((-2))
+        segment2.scaleBy(-2)
         coordinates2 = tuple((point.x, point.y) for point in segment2.points)
         self.assertEqual(coordinates1, coordinates2)
 
@@ -1559,9 +1559,9 @@ class TestDeprecated(unittest.TestCase):
         point1 = self.getPoint()
         point2 = self.getPoint()
         with self.assertWarnsRegex(DeprecationWarning, "Point.scale()"):
-            point1.scale((-2))
+            point1.scale(-2)
         self.assertNotEqual((point1.x, point1.y), (point2.x, point2.y))
-        point2.scaleBy((-2))
+        point2.scaleBy(-2)
         self.assertEqual((point1.x, point1.y), (point2.x, point2.y))
 
     def test_point_deprecated_scale_center(self):
@@ -1710,9 +1710,9 @@ class TestDeprecated(unittest.TestCase):
         bPoint1 = self.getBPoint()
         bPoint2 = self.getBPoint()
         with self.assertWarnsRegex(DeprecationWarning, "BPoint.scale()"):
-            bPoint1.scale((-2))
+            bPoint1.scale(-2)
         self.assertNotEqual(bPoint1.anchor, bPoint2.anchor)
-        bPoint2.scaleBy((-2))
+        bPoint2.scaleBy(-2)
         self.assertEqual(bPoint1.anchor, bPoint2.anchor)
 
     def test_bPoint_deprecated_scale_center(self):

--- a/Lib/fontParts/test/test_guideline.py
+++ b/Lib/fontParts/test/test_guideline.py
@@ -532,7 +532,7 @@ class TestGuideline(unittest.TestCase):
 
     def test_scaleBy_valid_one_value_no_origin(self):
         guideline = self.getGuideline_transform()
-        guideline.scaleBy((-2))
+        guideline.scaleBy(-2)
         self.assertEqual(guideline.x, -2)
         self.assertEqual(guideline.y, -4)
         self.assertAlmostEqual(guideline.angle, 225.000, places=3)

--- a/Lib/fontParts/test/test_image.py
+++ b/Lib/fontParts/test/test_image.py
@@ -347,7 +347,7 @@ class TestImage(unittest.TestCase):
     def test_bool_data_len_zero(self):
         image, _ = self.objectGenerator("image")
         try:
-            image.data = "".encode("utf-8")
+            image.data = b""
         except FontPartsError:
             raise unittest.SkipTest("Cannot set zero data")
         self.assertFalse(image)

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -55,8 +55,8 @@ class TestLayer(unittest.TestCase):
         layer.newGlyph("A", clear=False, rename=True)
 
         self.assertIn("A", layer)
-        self.assertIn("A.1",layer)
-        self.assertIn("A.2",layer)
+        self.assertIn("A.1", layer)
+        self.assertIn("A.2", layer)
 
     # ----
     # Hash

--- a/Lib/fontParts/test/test_layer.py
+++ b/Lib/fontParts/test/test_layer.py
@@ -49,7 +49,7 @@ class TestLayer(unittest.TestCase):
 
     def test_newGlyph_rename(self):
         layer = self.getLayer_glyphs()
-        original = layer["A"]
+        layer["A"]
 
         layer.newGlyph("A", clear=False, rename=True)
         layer.newGlyph("A", clear=False, rename=True)

--- a/Lib/fontParts/test/test_point.py
+++ b/Lib/fontParts/test/test_point.py
@@ -573,7 +573,7 @@ class TestPoint(unittest.TestCase):
 
     def test_scaleBy_valid_one_value_no_origin(self):
         point = self.getPoint_generic()
-        point.scaleBy((-2))
+        point.scaleBy(-2)
         self.assertEqual((point.x, point.y), (-202.0, -404.0))
 
     def test_scaleBy_valid_two_values_no_origin(self):

--- a/Lib/fontParts/ui.py
+++ b/Lib/fontParts/ui.py
@@ -166,7 +166,7 @@ def Message(
     :param title: The optional title of the dialog window as a :class:`str`.
         Defaults to ``"FontParts"``.
     :param informativeText: The optional additional informative text to display in the
-        dialog as  a :class:`str`. Defaults to :obj`None`.
+        dialog as a :class:`str`. Defaults to :obj:`None`.
 
     Example::
 

--- a/Lib/fontParts/world.py
+++ b/Lib/fontParts/world.py
@@ -420,7 +420,7 @@ class BaseFontList(list):
         Sorting options may be defined as follows:
 
         - A :ref:`sort description <sort-descriptions>` as a :class:`str`
-        - A :ref:`font info attribute name` <info-attributes` as a :class:`str`
+        - A :ref:`font info attribute name <info-attributes>` as a :class:`str`
         - A custom `sort value function <sort-value-function>`
         - A :class:`list` or :class:`tuple` containing a mix of any of the above
         - The special keyword ``"magic"`` (see :ref:`magic-sorting`)

--- a/Lib/fontParts/world.py
+++ b/Lib/fontParts/world.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 import os
 import glob
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
+from collections.abc import Callable, Iterable
 from collections.abc import Generator
 from types import FunctionType
 
@@ -32,14 +33,14 @@ BaseTypes = Union[
     "BaseGuideline",
     "BaseFontList",
 ]
-RegistryType = Dict[str, Optional[Callable[[], BaseTypes]]]
+RegistryType = dict[str, Optional[Callable[[], BaseTypes]]]
 InfoType = Union[str, int, float, bool]
 
 
 def OpenFonts(
-    directory: Optional[Union[str, CollectionType[str]]] = None,
+    directory: str | CollectionType[str] | None = None,
     showInterface: bool = True,
-    fileExtensions: Optional[CollectionType[str]] = None,
+    fileExtensions: CollectionType[str] | None = None,
 ) -> Generator[BaseFont]:
     """Open all fonts located in the specified directories.
 
@@ -117,8 +118,8 @@ def OpenFont(path: str, showInterface: bool = True) -> BaseFont:
 
 
 def NewFont(
-    familyName: Optional[str] = None,
-    styleName: Optional[str] = None,
+    familyName: str | None = None,
+    styleName: str | None = None,
     showInterface: bool = True,
 ) -> BaseFont:
     """Create a new font.
@@ -187,7 +188,7 @@ def CurrentLayer() -> BaseLayer:
     return dispatcher["CurrentLayer"]()
 
 
-def CurrentContours() -> Tuple[BaseContour, ...]:
+def CurrentContours() -> tuple[BaseContour, ...]:
     """Get the currently selected contours from :func:`CurrentGlyph`.
 
     :return: A :class:`tuple` of :class:`BaseContour` subclass instances representing
@@ -204,14 +205,14 @@ def CurrentContours() -> Tuple[BaseContour, ...]:
     return dispatcher["CurrentContours"]()
 
 
-def _defaultCurrentContours() -> Tuple[BaseContour, ...]:
+def _defaultCurrentContours() -> tuple[BaseContour, ...]:
     glyph = CurrentGlyph()
     if glyph is None:
         return ()
     return glyph.selectedContours
 
 
-def CurrentSegments() -> Tuple[BaseSegment, ...]:
+def CurrentSegments() -> tuple[BaseSegment, ...]:
     """Get the currently selected segments from :func:`CurrentContours`.
 
     :return: A :class:`tuple` of :class:`BaseSegments` subclass instances representing
@@ -228,7 +229,7 @@ def CurrentSegments() -> Tuple[BaseSegment, ...]:
     return dispatcher["CurrentSegments"]()
 
 
-def _defaultCurrentSegments() -> Tuple[BaseSegment, ...]:
+def _defaultCurrentSegments() -> tuple[BaseSegment, ...]:
     glyph = CurrentGlyph()
     if glyph is None:
         return ()
@@ -238,7 +239,7 @@ def _defaultCurrentSegments() -> Tuple[BaseSegment, ...]:
     return tuple(segments)
 
 
-def CurrentPoints() -> Tuple[BasePoint, ...]:
+def CurrentPoints() -> tuple[BasePoint, ...]:
     """Get the currently selected points from :func:`CurrentContours`.
 
     :return: A :class:`tuple` of :class:`BasePoint` subclass instances representing
@@ -255,7 +256,7 @@ def CurrentPoints() -> Tuple[BasePoint, ...]:
     return dispatcher["CurrentPoints"]()
 
 
-def _defaultCurrentPoints() -> Tuple[BasePoint, ...]:
+def _defaultCurrentPoints() -> tuple[BasePoint, ...]:
     glyph = CurrentGlyph()
     if glyph is None:
         return ()
@@ -265,7 +266,7 @@ def _defaultCurrentPoints() -> Tuple[BasePoint, ...]:
     return tuple(points)
 
 
-def CurrentComponents() -> Tuple[BaseComponent, ...]:
+def CurrentComponents() -> tuple[BaseComponent, ...]:
     """Get the currently selected components from :func:`CurrentGlyph`.
 
     :return: A :class:`tuple` of :class:`BaseComponent` subclass instances representing
@@ -282,14 +283,14 @@ def CurrentComponents() -> Tuple[BaseComponent, ...]:
     return dispatcher["CurrentComponents"]()
 
 
-def _defaultCurrentComponents() -> Tuple[BaseComponent, ...]:
+def _defaultCurrentComponents() -> tuple[BaseComponent, ...]:
     glyph = CurrentGlyph()
     if glyph is None:
         return ()
     return glyph.selectedComponents
 
 
-def CurrentAnchors() -> Tuple[BaseAnchor, ...]:
+def CurrentAnchors() -> tuple[BaseAnchor, ...]:
     """Get the currently selected anchors from :func:`CurrentGlyph`.
 
     :return: A :class:`tuple` of :class:`BaseAnchor` subclass instances representing
@@ -306,14 +307,14 @@ def CurrentAnchors() -> Tuple[BaseAnchor, ...]:
     return dispatcher["CurrentAnchors"]()
 
 
-def _defaultCurrentAnchors() -> Tuple[BaseAnchor, ...]:
+def _defaultCurrentAnchors() -> tuple[BaseAnchor, ...]:
     glyph = CurrentGlyph()
     if glyph is None:
         return ()
     return glyph.selectedAnchors
 
 
-def CurrentGuidelines() -> Tuple[BaseGuideline, ...]:
+def CurrentGuidelines() -> tuple[BaseGuideline, ...]:
     """Get the currently selected guidelines from :func:`CurrentGlyph`.
 
     This will include both font level and glyph level guidelines.
@@ -332,7 +333,7 @@ def CurrentGuidelines() -> Tuple[BaseGuideline, ...]:
     return dispatcher["CurrentGuidelines"]()
 
 
-def _defaultCurrentGuidelines() -> Tuple[BaseGuideline, ...]:
+def _defaultCurrentGuidelines() -> tuple[BaseGuideline, ...]:
     guidelines = []
     font = CurrentFont()
     if font is not None:
@@ -343,7 +344,7 @@ def _defaultCurrentGuidelines() -> Tuple[BaseGuideline, ...]:
     return tuple(guidelines)
 
 
-def AllFonts(sortOptions: Optional[CollectionType[str]] = None) -> BaseFontList:
+def AllFonts(sortOptions: CollectionType[str] | None = None) -> BaseFontList:
     """Get a list of all open fonts.
 
     Optionally, provide a value for `sortOptions` to sort the fonts. See
@@ -376,7 +377,7 @@ def AllFonts(sortOptions: Optional[CollectionType[str]] = None) -> BaseFontList:
     return fontList
 
 
-def RFont(path: Optional[str] = None, showInterface: bool = True) -> fontshell.RFont:
+def RFont(path: str | None = None, showInterface: bool = True) -> fontshell.RFont:
     return dispatcher["RFont"](pathOrObject=path, showInterface=showInterface)
 
 
@@ -389,7 +390,7 @@ def RGlyph() -> fontshell.RGlyph:
 # ---------
 
 
-def FontList(fonts: Optional[Iterable[T]] = None):
+def FontList(fonts: Iterable[T] | None = None):
     """Get a list with font-specific methods.
 
     :return: A :class:`BaseFontList` instance.
@@ -570,7 +571,7 @@ class BaseFontList(list):
     # Search
 
     def getFontsByFontInfoAttribute(
-        self, *attributeValuePairs: Tuple[str, InfoType]
+        self, *attributeValuePairs: tuple[str, InfoType]
     ) -> BaseFontList:
         r"""Get a list of fonts that match the specified attribute-value pairs.
 
@@ -595,7 +596,7 @@ class BaseFontList(list):
         return found
 
     def _matchFontInfoAttributes(
-        self, fonts: BaseFontList, attributeValuePair: Tuple[str, InfoType]
+        self, fonts: BaseFontList, attributeValuePair: tuple[str, InfoType]
     ) -> BaseFontList:
         found = self.__class__()
         attr, value = attributeValuePair
@@ -745,7 +746,7 @@ class _EnvironmentDispatcher:
     def __init__(self, registryItems: CollectionType[str]) -> None:
         self._registry: RegistryType = {item: None for item in registryItems}
 
-    def __setitem__(self, name: str, func: Optional[Callable]) -> None:
+    def __setitem__(self, name: str, func: Callable | None) -> None:
         self._registry[name] = func
 
     def __getitem__(self, name: str) -> Callable:
@@ -812,7 +813,7 @@ try:
     # OpenFont, RFont
 
     def _fontshellRFont(
-        pathOrObject: Optional[Union[str, BaseFont]] = None, showInterface: bool = True
+        pathOrObject: str | BaseFont | None = None, showInterface: bool = True
     ) -> fontshell.RFont:
         return fontshell.RFont(pathOrObject=pathOrObject, showInterface=showInterface)
 
@@ -822,8 +823,8 @@ try:
     # NewFont
 
     def _fontshellNewFont(
-        familyName: Optional[str] = None,
-        styleName: Optional[str] = None,
+        familyName: str | None = None,
+        styleName: str | None = None,
         showInterface: bool = True,
     ) -> fontshell.RFont:
         font = fontshell.RFont(showInterface=showInterface)


### PR DESCRIPTION
Builds on #884 to update type hints throughout the codebase.

I've run pyupgrade as suggested by @knutnergaard ~and then I renamed the shape-based aliases to domain names as discussed with @typemytype (similar to https://github.com/typemytype/drawbot/blob/master/drawBot/aliases.py).~

I will rename the shape-based aliases in a separate PR, this has become already pretty large.