### PR TITLE
Align methods with loose-in/strict-out rule

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -429,7 +429,7 @@ class BaseAnchor(
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
+    def _get_color(self) -> QuadrupleType[float] | None:
         """Get the native anchor's color.
 
         This is the environment implementation of the :attr:`BaseAnchor.color`
@@ -448,7 +448,7 @@ class BaseAnchor(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleType[float] | None) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         """Set the native anchor's color.
 
         Description

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -1,6 +1,6 @@
 # pylint: disable=C0103, C0114
 from __future__ import annotations
-from typing import Dict, List, Optional, Protocol, Tuple, TypeVar, Union
+from typing import Protocol, TypeVar
 import datetime
 
 from fontTools.pens.basePen import AbstractPen
@@ -13,16 +13,16 @@ PairType = tuple[T, T]
 QuadrupleType = tuple[T, T, T, T]
 QuintupleType = tuple[T, T, T, T, T]
 SextupleType = tuple[T, T, T, T, T, T]
-CollectionType = Union[list[T], tuple[T, ...]]
-PairCollectionType = Union[list[T], PairType[T]]
-QuadrupleCollectionType = Union[list[T], QuadrupleType[T]]
-SextupleCollectionType = Union[list[T], SextupleType[T]]
+CollectionType = list[T] | tuple[T, ...]
+PairCollectionType = list[T] | PairType[T]
+QuadrupleCollectionType = list[T] | QuadrupleType[T]
+SextupleCollectionType = list[T] | SextupleType[T]
 
 # Builtins
-IntFloatType = Union[int, float]
+IntFloatType = int | float
 
 # Compatibility
-DiffType = list[tuple[int, Optional[str], Optional[str]]]
+DiffType = list[tuple[int, str | None, str | None]]
 
 # Pens
 PenType = AbstractPen
@@ -36,16 +36,16 @@ ReverseComponentMappingType = dict[str, tuple[str, ...]]
 KerningDictType = dict[PairType[str], PairType[str]]
 
 # Lib
-LibValueType = Union[
-    str,
-    IntFloatType,
-    bool,
-    CollectionType["LibValueType"],
-    dict[str, "LibValueType"],
-    bytes,
-    bytearray,
-    datetime.datetime,
-]
+LibValueType = (
+    str
+    | IntFloatType
+    | bool
+    | CollectionType["LibValueType"]
+    | dict[str, "LibValueType"]
+    | bytes
+    | bytearray
+    | datetime.datetime
+)
 
 
 class LibValue:
@@ -69,7 +69,7 @@ class LibValue:
 
 
 # Transformation
-TransformationType = Union[IntFloatType, list[IntFloatType], PairType[IntFloatType]]
+TransformationType = IntFloatType | list[IntFloatType] | PairType[IntFloatType]
 
 # Interpolation
 InterpolatableType = TypeVar("InterpolatableType", bound="Interpolatable")

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -1059,7 +1059,7 @@ class TransformationMixin(ABC):
         value = normalizers.normalizeTransformationOffset(value)
         self._moveBy(value)
 
-    def _moveBy(self, value: PairType[IntFloatType], **kwargs: Any) -> None:
+    def _moveBy(self, value: PairCollectionType[IntFloatType], **kwargs: Any) -> None:
         r"""Move the native object according to the given coordinates.
 
         This is the environment implementation of :meth:`BaseObject.moveBy`.
@@ -1106,7 +1106,10 @@ class TransformationMixin(ABC):
         self._scaleBy(value, origin=origin)
 
     def _scaleBy(
-        self, value: PairType[float], origin: PairType[IntFloatType], **kwargs: Any
+        self,
+        value: PairCollectionType[IntFloatType],
+        origin: PairCollectionType[IntFloatType],
+        **kwargs: Any,
     ) -> None:
         r"""Scale the native object according to the given values.
 
@@ -1157,7 +1160,7 @@ class TransformationMixin(ABC):
         self._rotateBy(value, origin=origin)
 
     def _rotateBy(
-        self, value: float, origin: PairType[IntFloatType], **kwargs: Any
+        self, value: float, origin: PairCollectionType[IntFloatType], **kwargs: Any
     ) -> None:
         r"""Rotate the native object by the specified value.
 
@@ -1208,7 +1211,10 @@ class TransformationMixin(ABC):
         self._skewBy(value, origin=origin)
 
     def _skewBy(
-        self, value: PairType[float], origin: PairType[IntFloatType], **kwargs: Any
+        self,
+        value: PairCollectionType[IntFloatType],
+        origin: PairCollectionType[IntFloatType],
+        **kwargs: Any,
     ) -> None:
         r"""Skew the native object by the given value.
 

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1,6 +1,6 @@
 # pylint: disable=C0103, C0302, C0114, W0613
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Optional, Union, List, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 from collections.abc import Iterator
 from itertools import zip_longest
 from collections import Counter
@@ -2831,7 +2831,7 @@ class BaseGlyph(
 
 
         """
-        GuidelineListType = list[tuple[Optional[str], int]]
+        GuidelineListType = list[tuple[str | None, int]]
 
         glyph1 = self
         glyph2 = other

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2738,7 +2738,7 @@ class BaseGlyph(
 
     def _interpolate(
         self,
-        factor: tuple[IntFloatType, IntFloatType],
+        factor: PairCollectionType[IntFloatType],
         minGlyph: BaseGlyph,
         maxGlyph: BaseGlyph,
         round: bool,
@@ -3424,7 +3424,7 @@ class BaseGlyph(
         self._set_markColor(value)
 
     # type: ignore[return]
-    def _get_markColor(self) -> QuadrupleCollectionType[IntFloatType] | None:
+    def _get_markColor(self) -> QuadrupleType[float] | None:
         """Get the glyph's mark color.
 
         This is the environment implementation of
@@ -3442,7 +3442,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def _set_markColor(self, value: QuadrupleType[float] | None) -> None:
+    def _set_markColor(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         """Set the glyph's mark color.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -3442,7 +3442,9 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def _set_markColor(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_markColor(
+        self, value: QuadrupleCollectionType[IntFloatType] | None
+    ) -> None:
         """Set the glyph's mark color.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -3000,13 +3000,13 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_bounds(self) -> QuadrupleType[IntFloatType] | None:
+    def _get_base_bounds(self) -> QuadrupleType[float] | None:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> QuadrupleType[IntFloatType] | None:
+    def _get_bounds(self) -> QuadrupleType[float] | None:
         """Get the bounds of the native glyph.
 
         This is the environment implementation of the :attr:`BaseGlyph.bounds`

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -564,7 +564,7 @@ class BaseGuideline(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleType[float] | None) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         """Set the native guideline's color.
 
         This is the environment implementation of the :attr:`BaseGuideline.color`

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -175,7 +175,7 @@ class BaseImage(
         value = normalizers.normalizeTransformationMatrix(value)
         self._set_transformation(value)
 
-    def _get_transformation(self) -> SextupleCollectionType[IntFloatType]:
+    def _get_transformation(self) -> SextupleType[float]:
         """Get the native image's transformation matrix.
 
         This is the environment implementation of the
@@ -238,7 +238,7 @@ class BaseImage(
         value = normalizers.normalizeTransformationOffset(value)
         self._set_offset(value)
 
-    def _get_offset(self) -> PairCollectionType[IntFloatType]:
+    def _get_offset(self) -> PairType[IntFloatType]:
         """Get the native image's offset.
 
         This is the environment implementation of the :attr:`BaseImage.offset`
@@ -256,7 +256,7 @@ class BaseImage(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return (ox, oy)
 
-    def _set_offset(self, value: PairType[IntFloatType]) -> None:
+    def _set_offset(self, value: PairCollectionType[IntFloatType]) -> None:
         """Set the native image's offset.
 
         This is the environment implementation of the :attr:`BaseImage.offset`
@@ -302,7 +302,7 @@ class BaseImage(
         value = normalizers.normalizeTransformationScale(value)
         self._set_scale(value)
 
-    def _get_scale(self) -> TransformationType:
+    def _get_scale(self) -> PairType[float]:
         """Get the native image's scale.
 
         This is the environment implementation of the :attr:`BaseImage.scale`
@@ -320,7 +320,7 @@ class BaseImage(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return (sx, sy)
 
-    def _set_scale(self, value: PairType[float]) -> None:
+    def _set_scale(self, value: PairCollectionType[IntFloatType]) -> None:
         """Set the native image's scale.
 
         This is the environment implementation of the :attr:`BaseImage.scale`
@@ -373,7 +373,7 @@ class BaseImage(
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
+    def _get_color(self) -> QuadrupleType[float] | None:
         """Get the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`
@@ -392,7 +392,7 @@ class BaseImage(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleType[float] | None) -> None:
+    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
         """Set the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -327,7 +327,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> myKerning.remove(("A", "V"))
 
         """
-        del self[(pair[0], pair[1])]
+        one, two = pair
+        del self[(one, two)]
 
     def asDict(self, returnIntegers: bool = True) -> dict[PairType[str], IntFloatType]:
         """Return the kerning as a dictionary.

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -1,24 +1,22 @@
 # pylint: disable=C0103, C0114
 from __future__ import annotations
-from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
-from collections.abc import Callable, Iterator
-from collections.abc import MutableMapping
 
-from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
+from collections.abc import Callable, Iterator, MutableMapping
+from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
+
 from fontParts.base import normalizers
-from fontParts.base.deprecated import DeprecatedKerning, RemovedKerning
 from fontParts.base.annotations import (
     IntFloatType,
-    PairType,
     PairCollectionType,
+    PairType,
     TransformationType,
 )
+from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
+from fontParts.base.deprecated import DeprecatedKerning, RemovedKerning
 
 if TYPE_CHECKING:
+    from fontParts.base.base import BaseItems, BaseKeys, BaseValues
     from fontParts.base.font import BaseFont
-    from fontParts.base.base import BaseItems
-    from fontParts.base.base import BaseKeys
-    from fontParts.base.base import BaseValues
 
 BaseKerningType = TypeVar("BaseKerningType", bound="BaseKerning")
 
@@ -260,8 +258,8 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             Subclasses may override this method.
 
         """
-        from fontMath.mathFunctions import setRoundIntegerFunction
         from fontMath import MathKerning
+        from fontMath.mathFunctions import setRoundIntegerFunction
 
         setRoundIntegerFunction(normalizers.normalizeVisualRounding)
         kerningGroupCompatibility = self._testKerningGroupCompatibility(

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -117,7 +117,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         factor = normalizers.normalizeTransformationScale(factor)
         self._scale(factor)
 
-    def _scale(self, factor: PairType[float]) -> None:
+    def _scale(self, factor: PairCollectionType[IntFloatType]) -> None:
         """Scale all native kerning values by the specified factor.
 
         This is the environment implementation of :meth:`BaseKerning.scaleBy`.
@@ -231,7 +231,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     def _interpolate(
         self,
-        factor: PairType[float],
+        factor: PairCollectionType[IntFloatType],
         minKerning: BaseKerning,
         maxKerning: BaseKerning,
         round: bool,
@@ -313,7 +313,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
     # RoboFab Compatibility
     # ---------------------
 
-    def remove(self, pair: PairType[str]) -> None:
+    def remove(self, pair: PairCollectionType[str]) -> None:
         """Remove the specified pair from the Kerning.
 
         :param pair: The pair to remove as a :class:`tuple` of two :class:`str` values.
@@ -327,7 +327,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> myKerning.remove(("A", "V"))
 
         """
-        del self[pair]
+        del self[(pair[0], pair[1])]
 
     def asDict(self, returnIntegers: bool = True) -> dict[PairType[str], IntFloatType]:
         """Return the kerning as a dictionary.
@@ -463,7 +463,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         super().clear()
 
     def get(
-        self, pair: PairType[str], default: IntFloatType | None = None
+        self, pair: PairCollectionType[str], default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Get the value for the given kerning pair.
 
@@ -519,7 +519,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return value
 
     def _find(
-        self, pair: PairType[str], default: IntFloatType | None = None
+        self, pair: PairCollectionType[str], default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Get the value for the given explicit or implicit native kerning pair.
 

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -20,6 +20,7 @@ from fontParts.base.annotations import (
     CharacterMappingType,
     CollectionType,
     QuadrupleCollectionType,
+    QuadrupleType,
     TransformationType,
     ReverseComponentMappingType,
     IntFloatType,
@@ -845,7 +846,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:  # type: ignore[return]
+    def _get_color(self) -> QuadrupleType[float] | None:  # type: ignore[return]
         """Get the color of the layer.
 
         This is the environment implementation of

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -112,7 +112,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     # Bounds
     # ------
 
-    def _get_bounds(self) -> QuadrupleType[IntFloatType] | None:
+    def _get_bounds(self) -> QuadrupleType[float] | None:
         return self.naked().bounds
 
     # ----

--- a/Lib/fontParts/fontshell/layer.py
+++ b/Lib/fontParts/fontshell/layer.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING, Optional, Tuple, Dict, Any
 
 import defcon
 from fontParts.base import BaseLayer
-from fontParts.base.annotations import QuadrupleCollectionType, QuadrupleType, IntFloatType
+from fontParts.base.annotations import (
+    QuadrupleCollectionType,
+    QuadrupleType,
+    IntFloatType,
+)
 from fontParts.fontshell.base import RBaseObject
 from fontParts.fontshell.lib import RLib
 from fontParts.fontshell.glyph import RGlyph

--- a/Lib/fontParts/fontshell/layer.py
+++ b/Lib/fontParts/fontshell/layer.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Dict, Any
 
 import defcon
 from fontParts.base import BaseLayer
-from fontParts.base.annotations import QuadrupleCollectionType, IntFloatType
+from fontParts.base.annotations import QuadrupleCollectionType, QuadrupleType, IntFloatType
 from fontParts.fontshell.base import RBaseObject
 from fontParts.fontshell.lib import RLib
 from fontParts.fontshell.glyph import RGlyph
@@ -45,7 +45,7 @@ class RLayer(RBaseObject, BaseLayer):
 
     # color
 
-    def _get_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
+    def _get_color(self) -> QuadrupleType[float] | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)


### PR DESCRIPTION
Refers to [this](https://github.com/robotools/fontParts/pull/879#issuecomment-4552602368) exchange in the #879 PR.
I've also completed some missing updates from pyupgrade.

(I have another PR coming stacked on top of this one)