### PR TITLE
Replace shape-based aliases with per-domain aliases

### DIFF
--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -472,9 +472,7 @@ class BaseAnchor(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native anchor according to the given matrix.
 
         This is the environment implementation of :meth:`BaseAnchor.transformBy`.

--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -18,9 +18,9 @@ from fontParts.base.compatibility import AnchorCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedAnchor, RemovedAnchor
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     RGBALike,
     RGBA,
-    SextupleCollectionType,
     IntFloatType,
 )
 
@@ -473,7 +473,7 @@ class BaseAnchor(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native anchor according to the given matrix.
 

--- a/Lib/fontParts/base/anchor.py
+++ b/Lib/fontParts/base/anchor.py
@@ -18,8 +18,8 @@ from fontParts.base.compatibility import AnchorCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedAnchor, RemovedAnchor
 from fontParts.base.annotations import (
-    QuadrupleType,
-    QuadrupleCollectionType,
+    RGBALike,
+    RGBA,
     SextupleCollectionType,
     IntFloatType,
 )
@@ -424,12 +424,12 @@ class BaseAnchor(
             value = Color(value)
         return value
 
-    def _set_base_color(self, value: QuadrupleCollectionType[IntFloatType]) -> None:
+    def _set_base_color(self, value: RGBALike) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         """Get the native anchor's color.
 
         This is the environment implementation of the :attr:`BaseAnchor.color`
@@ -448,7 +448,7 @@ class BaseAnchor(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         """Set the native anchor's color.
 
         Description

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -38,6 +38,10 @@ RGBALike = list[IntFloatType] | RGBA
 AffineTransformation = tuple[float, float, float, float, float, float]
 AffineTransformationLike = list[IntFloatType] | AffineTransformation
 
+# Kerning pair — (first, second) glyph or group names.
+KerningPair = tuple[str, str]
+KerningPairLike = list[str] | KerningPair
+
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]
 

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -34,6 +34,10 @@ BoundingBoxLike = list[IntFloatType] | BoundingBox
 RGBA = tuple[float, float, float, float]
 RGBALike = list[IntFloatType] | RGBA
 
+# Affine transformation matrix — (xx, xy, yx, yy, dx, dy).
+AffineTransformation = tuple[float, float, float, float, float, float]
+AffineTransformationLike = list[IntFloatType] | AffineTransformation
+
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]
 

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -10,14 +10,7 @@ from fontTools.pens.pointPen import AbstractPointPen
 # Generic
 T = TypeVar("T")
 
-PairType = tuple[T, T]
-QuadrupleType = tuple[T, T, T, T]
-QuintupleType = tuple[T, T, T, T, T]
-SextupleType = tuple[T, T, T, T, T, T]
 CollectionType = list[T] | tuple[T, ...]
-PairCollectionType = list[T] | PairType[T]
-QuadrupleCollectionType = list[T] | QuadrupleType[T]
-SextupleCollectionType = list[T] | SextupleType[T]
 
 # Builtins
 IntFloatType = int | float
@@ -69,7 +62,7 @@ CharacterMappingType = dict[int, tuple[str, ...]]
 ReverseComponentMappingType = dict[str, tuple[str, ...]]
 
 # Kerning
-KerningDictType = dict[PairType[str], PairType[str]]
+KerningDictType = dict[KerningPair, KerningPair]
 
 # Lib
 LibValueType = (
@@ -103,9 +96,6 @@ class LibValue:
 
     """
 
-
-# Transformation
-TransformationType = IntFloatType | list[IntFloatType] | PairType[IntFloatType]
 
 # Interpolation
 InterpolatableType = TypeVar("InterpolatableType", bound="Interpolatable")

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -1,7 +1,8 @@
 # pylint: disable=C0103, C0114
 from __future__ import annotations
-from typing import Protocol, TypeVar
+
 import datetime
+from typing import Protocol, TypeVar
 
 from fontTools.pens.basePen import AbstractPen
 from fontTools.pens.pointPen import AbstractPointPen
@@ -21,9 +22,13 @@ SextupleCollectionType = list[T] | SextupleType[T]
 # Builtins
 IntFloatType = int | float
 
-# point / offset / anchor (bPoints)
+# Point / Offset / Anchor (bPoints)
 Coordinate = tuple[IntFloatType, IntFloatType]
 CoordinateLike = list[IntFloatType] | Coordinate
+
+# Bounding box — (xMin, yMin, xMax, yMax).
+BoundingBox = tuple[float, float, float, float]
+BoundingBoxLike = list[IntFloatType] | BoundingBox
 
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -42,6 +42,21 @@ AffineTransformationLike = list[IntFloatType] | AffineTransformation
 KerningPair = tuple[str, str]
 KerningPairLike = list[str] | KerningPair
 
+# Scale factor — (sx, sy) multiplicative pair.
+ScaleFactor = tuple[float, float]
+ScaleFactorPair = list[IntFloatType] | ScaleFactor
+ScaleFactorLike = IntFloatType | ScaleFactorPair
+
+# Skew angle — (xAngle, yAngle) in degrees.
+SkewAngle = tuple[float, float]
+SkewAnglePair = list[IntFloatType] | SkewAngle
+SkewAngleLike = IntFloatType | SkewAnglePair
+
+# Interpolation factor — (xFactor, yFactor).
+InterpolationFactor = tuple[float, float]
+InterpolationFactorPair = list[IntFloatType] | InterpolationFactor
+InterpolationFactorLike = IntFloatType | InterpolationFactorPair
+
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]
 
@@ -108,5 +123,5 @@ class Interpolatable(Protocol):
     ) -> InterpolatableType: ...
 
     def __mul__(
-        self: InterpolatableType, other: TransformationType
+        self: InterpolatableType, other: InterpolationFactorLike
     ) -> InterpolatableType: ...

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -21,6 +21,10 @@ SextupleCollectionType = list[T] | SextupleType[T]
 # Builtins
 IntFloatType = int | float
 
+# point / offset / anchor (bPoints)
+Coordinate = tuple[IntFloatType, IntFloatType]
+CoordinateLike = list[IntFloatType] | Coordinate
+
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]
 

--- a/Lib/fontParts/base/annotations.py
+++ b/Lib/fontParts/base/annotations.py
@@ -30,6 +30,10 @@ CoordinateLike = list[IntFloatType] | Coordinate
 BoundingBox = tuple[float, float, float, float]
 BoundingBoxLike = list[IntFloatType] | BoundingBox
 
+# RGBA color — (r, g, b, a) in [0, 1]
+RGBA = tuple[float, float, float, float]
+RGBALike = list[IntFloatType] | RGBA
+
 # Compatibility
 DiffType = list[tuple[int, str | None, str | None]]
 

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -15,9 +15,9 @@ from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedBPoint, RemovedBPoint
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     Coordinate,
     CoordinateLike,
-    SextupleCollectionType,
     IntFloatType,
 )
 
@@ -617,7 +617,7 @@ class BaseBPoint(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native bPoint.
 

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -616,9 +616,7 @@ class BaseBPoint(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native bPoint.
 
         This is the environment implementation of :meth:`BaseBPoint.transformBy`.
@@ -678,9 +676,7 @@ class BaseBPoint(
         )
 
 
-def relativeBCPIn(
-    anchor: CoordinateLike, BCPIn: CoordinateLike
-) -> Coordinate:
+def relativeBCPIn(anchor: CoordinateLike, BCPIn: CoordinateLike) -> Coordinate:
     """convert absolute incoming bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
@@ -693,9 +689,7 @@ def relativeBCPIn(
     return (BCPIn[0] - anchor[0], BCPIn[1] - anchor[1])
 
 
-def absoluteBCPIn(
-    anchor: CoordinateLike, BCPIn: CoordinateLike
-) -> Coordinate:
+def absoluteBCPIn(anchor: CoordinateLike, BCPIn: CoordinateLike) -> Coordinate:
     """convert relative incoming bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value
@@ -708,9 +702,7 @@ def absoluteBCPIn(
     return (BCPIn[0] + anchor[0], BCPIn[1] + anchor[1])
 
 
-def relativeBCPOut(
-    anchor: CoordinateLike, BCPOut: CoordinateLike
-) -> Coordinate:
+def relativeBCPOut(anchor: CoordinateLike, BCPOut: CoordinateLike) -> Coordinate:
     """convert absolute outgoing bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
@@ -723,9 +715,7 @@ def relativeBCPOut(
     return (BCPOut[0] - anchor[0], BCPOut[1] - anchor[1])
 
 
-def absoluteBCPOut(
-    anchor: CoordinateLike, BCPOut: CoordinateLike
-) -> Coordinate:
+def absoluteBCPOut(anchor: CoordinateLike, BCPOut: CoordinateLike) -> Coordinate:
     """convert relative outgoing bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value

--- a/Lib/fontParts/base/bPoint.py
+++ b/Lib/fontParts/base/bPoint.py
@@ -15,8 +15,8 @@ from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedBPoint, RemovedBPoint
 from fontParts.base.annotations import (
-    PairType,
-    PairCollectionType,
+    Coordinate,
+    CoordinateLike,
     SextupleCollectionType,
     IntFloatType,
 )
@@ -246,16 +246,16 @@ class BaseBPoint(
         """,
     )
 
-    def _get_base_anchor(self) -> PairType[IntFloatType]:
+    def _get_base_anchor(self) -> Coordinate:
         value = self._get_anchor()
         value = normalizers.normalizeCoordinateTuple(value)
         return value
 
-    def _set_base_anchor(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_anchor(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeCoordinateTuple(value)
         self._set_anchor(value)
 
-    def _get_anchor(self) -> PairType[IntFloatType]:
+    def _get_anchor(self) -> Coordinate:
         """Get the bPoint's anchor point.
 
         This is the environment implementation of the :attr:`BaseBPoint.anchor`
@@ -273,7 +273,7 @@ class BaseBPoint(
         point = self._point
         return (point.x, point.y)
 
-    def _set_anchor(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_anchor(self, value: CoordinateLike) -> None:
         """Set the bPoint's anchor point.
 
         This is the environment implementation of the :attr:`BaseBPoint.anchor`
@@ -308,16 +308,16 @@ class BaseBPoint(
         """,
     )
 
-    def _get_base_bcpIn(self) -> PairType[IntFloatType]:
+    def _get_base_bcpIn(self) -> Coordinate:
         value = self._get_bcpIn()
         value = normalizers.normalizeCoordinateTuple(value)
         return value
 
-    def _set_base_bcpIn(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_bcpIn(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeCoordinateTuple(value)
         self._set_bcpIn(value)
 
-    def _get_bcpIn(self) -> PairType[IntFloatType]:
+    def _get_bcpIn(self) -> Coordinate:
         """Get the bPoint's incoming off-curve.
 
         This is the environment implementation of the :attr:`BaseBPoint.bcpIn`
@@ -341,7 +341,7 @@ class BaseBPoint(
             x = y = 0
         return (x, y)
 
-    def _set_bcpIn(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_bcpIn(self, value: CoordinateLike) -> None:
         """Set the bPoint's incoming off-curve.
 
         This is the environment implementation of the :attr:`BaseBPoint.bcpIn`
@@ -395,16 +395,16 @@ class BaseBPoint(
         """,
     )
 
-    def _get_base_bcpOut(self) -> PairType[IntFloatType]:
+    def _get_base_bcpOut(self) -> Coordinate:
         value = self._get_bcpOut()
         value = normalizers.normalizeCoordinateTuple(value)
         return value
 
-    def _set_base_bcpOut(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_bcpOut(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeCoordinateTuple(value)
         self._set_bcpOut(value)
 
-    def _get_bcpOut(self) -> PairType[IntFloatType]:
+    def _get_bcpOut(self) -> Coordinate:
         """Get the bPoint's outgoing off-curve.
 
         This is the environment implementation of the :attr:`BaseBPoint.bcpOut`
@@ -428,7 +428,7 @@ class BaseBPoint(
             x = y = 0
         return (x, y)
 
-    def _set_bcpOut(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_bcpOut(self, value: CoordinateLike) -> None:
         """Set the bPoint's outgoing off-curve.
 
         This is the environment implementation of the :attr:`BaseBPoint.bcpOut`
@@ -679,8 +679,8 @@ class BaseBPoint(
 
 
 def relativeBCPIn(
-    anchor: PairCollectionType[IntFloatType], BCPIn: PairCollectionType[IntFloatType]
-) -> PairType[IntFloatType]:
+    anchor: CoordinateLike, BCPIn: CoordinateLike
+) -> Coordinate:
     """convert absolute incoming bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
@@ -694,8 +694,8 @@ def relativeBCPIn(
 
 
 def absoluteBCPIn(
-    anchor: PairCollectionType[IntFloatType], BCPIn: PairCollectionType[IntFloatType]
-) -> PairType[IntFloatType]:
+    anchor: CoordinateLike, BCPIn: CoordinateLike
+) -> Coordinate:
     """convert relative incoming bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value
@@ -709,8 +709,8 @@ def absoluteBCPIn(
 
 
 def relativeBCPOut(
-    anchor: PairCollectionType[IntFloatType], BCPOut: PairCollectionType[IntFloatType]
-) -> PairType[IntFloatType]:
+    anchor: CoordinateLike, BCPOut: CoordinateLike
+) -> Coordinate:
     """convert absolute outgoing bcp value to a relative value.
 
     :param anchor: The anchor reference point from which to measure the relative
@@ -724,8 +724,8 @@ def relativeBCPOut(
 
 
 def absoluteBCPOut(
-    anchor: PairCollectionType[IntFloatType], BCPOut: PairCollectionType[IntFloatType]
-) -> PairType[IntFloatType]:
+    anchor: CoordinateLike, BCPOut: CoordinateLike
+) -> Coordinate:
     """convert relative outgoing bcp value to an absolute value.
 
     :param anchor: The anchor reference point from which the relative BCP value

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -22,7 +22,8 @@ from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
-    PairType,
+    Coordinate,
+    CoordinateLike,
     PairCollectionType,
     SextupleCollectionType,
     IntFloatType,
@@ -996,7 +997,7 @@ class TransformationMixin(ABC):
     def transformBy(
         self,
         matrix: SextupleCollectionType[IntFloatType],
-        origin: PairCollectionType[IntFloatType] | None = None,
+        origin: CoordinateLike | None = None,
     ) -> None:
         """Transform the object according to the given matrix.
 
@@ -1045,7 +1046,7 @@ class TransformationMixin(ABC):
         """
         self.raiseNotImplementedError()
 
-    def moveBy(self, value: PairCollectionType[IntFloatType]) -> None:
+    def moveBy(self, value: CoordinateLike) -> None:
         """Move the object according to the given coordinates.
 
         :param value: The x and y values to move the object by as
@@ -1059,7 +1060,7 @@ class TransformationMixin(ABC):
         value = normalizers.normalizeTransformationOffset(value)
         self._moveBy(value)
 
-    def _moveBy(self, value: PairCollectionType[IntFloatType], **kwargs: Any) -> None:
+    def _moveBy(self, value: CoordinateLike, **kwargs: Any) -> None:
         r"""Move the native object according to the given coordinates.
 
         This is the environment implementation of :meth:`BaseObject.moveBy`.
@@ -1081,7 +1082,7 @@ class TransformationMixin(ABC):
     def scaleBy(
         self,
         value: TransformationType,
-        origin: PairCollectionType[IntFloatType] | None = None,
+        origin: CoordinateLike | None = None,
     ) -> None:
         """Scale the object according to the given values.
 
@@ -1108,7 +1109,7 @@ class TransformationMixin(ABC):
     def _scaleBy(
         self,
         value: PairCollectionType[IntFloatType],
-        origin: PairCollectionType[IntFloatType],
+        origin: CoordinateLike,
         **kwargs: Any,
     ) -> None:
         r"""Scale the native object according to the given values.
@@ -1137,7 +1138,7 @@ class TransformationMixin(ABC):
     def rotateBy(
         self,
         value: IntFloatType,
-        origin: PairCollectionType[IntFloatType] | None = None,
+        origin: CoordinateLike | None = None,
     ) -> None:
         """Rotate the object by the specified value.
 
@@ -1160,7 +1161,7 @@ class TransformationMixin(ABC):
         self._rotateBy(value, origin=origin)
 
     def _rotateBy(
-        self, value: float, origin: PairCollectionType[IntFloatType], **kwargs: Any
+        self, value: float, origin: CoordinateLike, **kwargs: Any
     ) -> None:
         r"""Rotate the native object by the specified value.
 
@@ -1186,7 +1187,7 @@ class TransformationMixin(ABC):
     def skewBy(
         self,
         value: TransformationType,
-        origin: PairCollectionType[IntFloatType] | None = None,
+        origin: CoordinateLike | None = None,
     ) -> None:
         """Skew the object by the given value.
 
@@ -1213,7 +1214,7 @@ class TransformationMixin(ABC):
     def _skewBy(
         self,
         value: PairCollectionType[IntFloatType],
-        origin: PairCollectionType[IntFloatType],
+        origin: CoordinateLike,
         **kwargs: Any,
     ) -> None:
         r"""Skew the native object by the given value.
@@ -1424,16 +1425,16 @@ class PointPositionMixin(ABC):
         """,
     )
 
-    def _get_base_position(self) -> PairType[IntFloatType]:
+    def _get_base_position(self) -> Coordinate:
         value = self._get_position()
         value = normalizers.normalizeCoordinateTuple(value)
         return value
 
-    def _set_base_position(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_position(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeCoordinateTuple(value)
         self._set_position(value)
 
-    def _get_position(self) -> PairType[IntFloatType]:
+    def _get_position(self) -> Coordinate:
         """Get the point position of the object.
 
         This is the environment implementation of
@@ -1450,7 +1451,7 @@ class PointPositionMixin(ABC):
         """
         return (self.x, self.y)
 
-    def _set_position(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_position(self, value: CoordinateLike) -> None:
         """Set the point position of the object.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -998,9 +998,7 @@ class TransformationMixin(ABC):
     # ---------------
 
     def transformBy(
-        self,
-        matrix: AffineTransformationLike,
-        origin: CoordinateLike | None = None,
+        self, matrix: AffineTransformationLike, origin: CoordinateLike | None = None
     ) -> None:
         """Transform the object according to the given matrix.
 
@@ -1028,9 +1026,7 @@ class TransformationMixin(ABC):
             matrix = tuple(t)
         self._transformBy(matrix)
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native object according to the given matrix.
 
         This is the environment implementation of :meth:`TransformationMixin.transformBy`.
@@ -1083,9 +1079,7 @@ class TransformationMixin(ABC):
         self.transformBy(tuple(t), **kwargs)
 
     def scaleBy(
-        self,
-        value: ScaleFactorLike,
-        origin: CoordinateLike | None = None,
+        self, value: ScaleFactorLike, origin: CoordinateLike | None = None
     ) -> None:
         """Scale the object according to the given values.
 
@@ -1110,10 +1104,7 @@ class TransformationMixin(ABC):
         self._scaleBy(value, origin=origin)
 
     def _scaleBy(
-        self,
-        value: ScaleFactorPair,
-        origin: CoordinateLike,
-        **kwargs: Any,
+        self, value: ScaleFactorPair, origin: CoordinateLike, **kwargs: Any
     ) -> None:
         r"""Scale the native object according to the given values.
 
@@ -1139,9 +1130,7 @@ class TransformationMixin(ABC):
         self.transformBy(tuple(t), origin=origin, **kwargs)
 
     def rotateBy(
-        self,
-        value: IntFloatType,
-        origin: CoordinateLike | None = None,
+        self, value: IntFloatType, origin: CoordinateLike | None = None
     ) -> None:
         """Rotate the object by the specified value.
 
@@ -1163,9 +1152,7 @@ class TransformationMixin(ABC):
         origin = normalizers.normalizeCoordinateTuple(origin)
         self._rotateBy(value, origin=origin)
 
-    def _rotateBy(
-        self, value: float, origin: CoordinateLike, **kwargs: Any
-    ) -> None:
+    def _rotateBy(self, value: float, origin: CoordinateLike, **kwargs: Any) -> None:
         r"""Rotate the native object by the specified value.
 
         This is the environment implementation of :meth:`TransformationMixin.rotateBy`.
@@ -1188,9 +1175,7 @@ class TransformationMixin(ABC):
         self.transformBy(tuple(t), origin=origin, **kwargs)
 
     def skewBy(
-        self,
-        value: SkewAngleLike,
-        origin: CoordinateLike | None = None,
+        self, value: SkewAngleLike, origin: CoordinateLike | None = None
     ) -> None:
         """Skew the object by the given value.
 
@@ -1215,10 +1200,7 @@ class TransformationMixin(ABC):
         self._skewBy(value, origin=origin)
 
     def _skewBy(
-        self,
-        value: SkewAnglePair,
-        origin: CoordinateLike,
-        **kwargs: Any,
+        self, value: SkewAnglePair, origin: CoordinateLike, **kwargs: Any
     ) -> None:
         r"""Skew the native object by the given value.
 

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -22,10 +22,10 @@ from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     Coordinate,
     CoordinateLike,
     PairCollectionType,
-    SextupleCollectionType,
     IntFloatType,
     TransformationType,
     InterpolatableType,
@@ -996,7 +996,7 @@ class TransformationMixin(ABC):
 
     def transformBy(
         self,
-        matrix: SextupleCollectionType[IntFloatType],
+        matrix: AffineTransformationLike,
         origin: CoordinateLike | None = None,
     ) -> None:
         """Transform the object according to the given matrix.
@@ -1026,7 +1026,7 @@ class TransformationMixin(ABC):
         self._transformBy(matrix)
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native object according to the given matrix.
 

--- a/Lib/fontParts/base/base.py
+++ b/Lib/fontParts/base/base.py
@@ -22,12 +22,15 @@ from fontTools.misc import transform
 from fontParts.base.errors import FontPartsError
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
+    InterpolationFactorLike,
+    SkewAngleLike,
+    SkewAnglePair,
+    ScaleFactorLike,
+    ScaleFactorPair,
     AffineTransformationLike,
     Coordinate,
     CoordinateLike,
-    PairCollectionType,
     IntFloatType,
-    TransformationType,
     InterpolatableType,
 )
 
@@ -152,7 +155,7 @@ class dynamicProperty:
 def interpolate(
     minValue: InterpolatableType,
     maxValue: InterpolatableType,
-    factor: TransformationType,
+    factor: InterpolationFactorLike,
 ) -> InterpolatableType:
     """Interpolate between two number-like objects.
 
@@ -1081,7 +1084,7 @@ class TransformationMixin(ABC):
 
     def scaleBy(
         self,
-        value: TransformationType,
+        value: ScaleFactorLike,
         origin: CoordinateLike | None = None,
     ) -> None:
         """Scale the object according to the given values.
@@ -1108,7 +1111,7 @@ class TransformationMixin(ABC):
 
     def _scaleBy(
         self,
-        value: PairCollectionType[IntFloatType],
+        value: ScaleFactorPair,
         origin: CoordinateLike,
         **kwargs: Any,
     ) -> None:
@@ -1186,7 +1189,7 @@ class TransformationMixin(ABC):
 
     def skewBy(
         self,
-        value: TransformationType,
+        value: SkewAngleLike,
         origin: CoordinateLike | None = None,
     ) -> None:
         """Skew the object by the given value.
@@ -1213,7 +1216,7 @@ class TransformationMixin(ABC):
 
     def _skewBy(
         self,
-        value: PairCollectionType[IntFloatType],
+        value: SkewAnglePair,
         origin: CoordinateLike,
         **kwargs: Any,
     ) -> None:

--- a/Lib/fontParts/base/color.py
+++ b/Lib/fontParts/base/color.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import Union
 
 from fontParts.base.normalizers import normalizeColor
-from fontParts.base.annotations import IntFloatType, QuadrupleCollectionType
+from fontParts.base.annotations import IntFloatType, RGBALike
 
 
 class Color(tuple):
@@ -14,7 +14,7 @@ class Color(tuple):
     """
 
     def __new__(
-        cls, *args: IntFloatType | QuadrupleCollectionType[IntFloatType]
+        cls, *args: IntFloatType | RGBALike
     ) -> Color:
         value = args[0] if len(args) == 1 else args
         normalizedValue = normalizeColor(value)  # type: ignore[arg-type]

--- a/Lib/fontParts/base/color.py
+++ b/Lib/fontParts/base/color.py
@@ -13,9 +13,7 @@ class Color(tuple):
 
     """
 
-    def __new__(
-        cls, *args: IntFloatType | RGBALike
-    ) -> Color:
+    def __new__(cls, *args: IntFloatType | RGBALike) -> Color:
         value = args[0] if len(args) == 1 else args
         normalizedValue = normalizeColor(value)  # type: ignore[arg-type]
 

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -19,13 +19,13 @@ from fontParts.base.base import (
 from fontParts.base.compatibility import ComponentCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedComponent, RemovedComponent
 from fontParts.base.annotations import (
+    ScaleFactorPair,
+    ScaleFactor,
     AffineTransformationLike,
     AffineTransformation,
     BoundingBox,
     Coordinate,
     CoordinateLike,
-    PairCollectionType,
-    PairType,
     IntFloatType,
     PenType,
     PointPenType,
@@ -355,16 +355,16 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_scale(self) -> PairType[float]:
+    def _get_base_scale(self) -> ScaleFactor:
         value = self._get_scale()
         value = normalizers.normalizeComponentScale(value)
         return value
 
-    def _set_base_scale(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_scale(self, value: ScaleFactorPair) -> None:
         value = normalizers.normalizeComponentScale(value)
         self._set_scale(value)
 
-    def _get_scale(self) -> PairType[float]:
+    def _get_scale(self) -> ScaleFactor:
         """Get the native component's scale.
 
         This is the environment implementation of the :attr:`BaseComponent.scale`
@@ -382,7 +382,7 @@ class BaseComponent(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return sx, sy
 
-    def _set_scale(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_scale(self, value: ScaleFactorPair) -> None:
         """Set the native component's scale.
 
         This is the environment implementation of the :attr:`BaseComponent.scale`

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -19,8 +19,10 @@ from fontParts.base.base import (
 from fontParts.base.compatibility import ComponentCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedComponent, RemovedComponent
 from fontParts.base.annotations import (
-    PairType,
+    Coordinate,
+    CoordinateLike,
     PairCollectionType,
+    PairType,
     QuadrupleType,
     SextupleType,
     SextupleCollectionType,
@@ -293,16 +295,16 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_offset(self) -> PairType[IntFloatType]:
+    def _get_base_offset(self) -> Coordinate:
         value = self._get_offset()
         value = normalizers.normalizeTransformationOffset(value)
         return value
 
-    def _set_base_offset(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_offset(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeTransformationOffset(value)
         self._set_offset(value)
 
-    def _get_offset(self) -> PairType[IntFloatType]:
+    def _get_offset(self) -> Coordinate:
         """Get the native component's offset.
 
         This is the environment implementation of the :attr:`BaseComponent.offset`
@@ -320,7 +322,7 @@ class BaseComponent(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return ox, oy
 
-    def _set_offset(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_offset(self, value: CoordinateLike) -> None:
         """Set the native component's offset.
 
         This is the environment implementation of the :attr:`BaseComponent.offset`
@@ -680,7 +682,7 @@ class BaseComponent(
     # Data Queries
     # ------------
 
-    def pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` lies inside the filled area of the component.
 
         :param point: The point to check as a :ref:`type-coordinate`.
@@ -696,7 +698,7 @@ class BaseComponent(
         point = normalizers.normalizeCoordinateTuple(point)
         return self._pointInside(point)
 
-    def _pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def _pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` lies inside the filled area of the native component.
 
         This is the environment implementation of :meth:`BaseComponent.pointInside`.

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -24,7 +24,6 @@ from fontParts.base.annotations import (
     CoordinateLike,
     PairCollectionType,
     PairType,
-    QuadrupleType,
     SextupleType,
     SextupleCollectionType,
     IntFloatType,

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -19,13 +19,13 @@ from fontParts.base.base import (
 from fontParts.base.compatibility import ComponentCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedComponent, RemovedComponent
 from fontParts.base.annotations import (
+    AffineTransformationLike,
+    AffineTransformation,
     BoundingBox,
     Coordinate,
     CoordinateLike,
     PairCollectionType,
     PairType,
-    SextupleType,
-    SextupleCollectionType,
     IntFloatType,
     PenType,
     PointPenType,
@@ -234,18 +234,18 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_transformation(self) -> SextupleType[float]:
+    def _get_base_transformation(self) -> AffineTransformation:
         value = self._get_transformation()
         value = normalizers.normalizeTransformationMatrix(value)
         return value
 
     def _set_base_transformation(
-        self, value: SextupleCollectionType[IntFloatType]
+        self, value: AffineTransformationLike
     ) -> None:
         value = normalizers.normalizeTransformationMatrix(value)
         self._set_transformation(value)
 
-    def _get_transformation(self) -> SextupleType[float]:
+    def _get_transformation(self) -> AffineTransformation:
         """Get the native component's transformation matrix.
 
         This is the environment implementation of the
@@ -264,7 +264,7 @@ class BaseComponent(
         """
         self.raiseNotImplementedError()
 
-    def _set_transformation(self, value: SextupleCollectionType[IntFloatType]) -> None:
+    def _set_transformation(self, value: AffineTransformationLike) -> None:
         """Set the native component's transformation matrix.
 
         This is the environment implementation of the
@@ -557,7 +557,7 @@ class BaseComponent(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the component according to the given matrix.
 

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -239,9 +239,7 @@ class BaseComponent(
         value = normalizers.normalizeTransformationMatrix(value)
         return value
 
-    def _set_base_transformation(
-        self, value: AffineTransformationLike
-    ) -> None:
+    def _set_base_transformation(self, value: AffineTransformationLike) -> None:
         value = normalizers.normalizeTransformationMatrix(value)
         self._set_transformation(value)
 
@@ -556,9 +554,7 @@ class BaseComponent(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the component according to the given matrix.
 
         This is the environment implementation of :meth:`BaseComponent.transformBy`.

--- a/Lib/fontParts/base/component.py
+++ b/Lib/fontParts/base/component.py
@@ -19,6 +19,7 @@ from fontParts.base.base import (
 from fontParts.base.compatibility import ComponentCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedComponent, RemovedComponent
 from fontParts.base.annotations import (
+    BoundingBox,
     Coordinate,
     CoordinateLike,
     PairCollectionType,
@@ -735,13 +736,13 @@ class BaseComponent(
         """,
     )
 
-    def _get_base_bounds(self) -> QuadrupleType[float]:
+    def _get_base_bounds(self) -> BoundingBox:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> QuadrupleType[float]:
+    def _get_bounds(self) -> BoundingBox:
         """Get the bounds of the component.
 
          This is the environment implementation of the :attr:`BaseComponent.bounds`

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -16,6 +16,7 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import ContourCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedContour, RemovedContour
 from fontParts.base.annotations import (
+    BoundingBox,
     Coordinate,
     CoordinateLike,
     QuadrupleType,
@@ -782,13 +783,13 @@ class BaseContour(
         """,
     )
 
-    def _get_base_bounds(self) -> QuadrupleType[float] | None:
+    def _get_base_bounds(self) -> BoundingBox | None:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> QuadrupleType[float] | None:
+    def _get_bounds(self) -> BoundingBox | None:
         """Get the bounds of the contour.
 
         This is the environment implementation of the :attr:`BaseContour.bounds`

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -454,9 +454,7 @@ class BaseContour(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the contour according to the given matrix.
 
         This is the environment implementation of :meth:`BaseContour.transformBy`.

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -19,7 +19,6 @@ from fontParts.base.annotations import (
     BoundingBox,
     Coordinate,
     CoordinateLike,
-    QuadrupleType,
     CollectionType,
     SextupleCollectionType,
     IntFloatType,

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -16,11 +16,11 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import ContourCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedContour, RemovedContour
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     BoundingBox,
     Coordinate,
     CoordinateLike,
     CollectionType,
-    SextupleCollectionType,
     IntFloatType,
     PenType,
     PointPenType,
@@ -455,7 +455,7 @@ class BaseContour(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the contour according to the given matrix.
 

--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -16,8 +16,9 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import ContourCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedContour, RemovedContour
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     QuadrupleType,
-    PairCollectionType,
     CollectionType,
     SextupleCollectionType,
     IntFloatType,
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
     from fontParts.base.font import BaseFont
 
 BaseContourType = TypeVar("BaseContourType", bound="BaseContour")
-PointCollectionType = CollectionType[PairCollectionType[IntFloatType]]
+PointCollectionType = CollectionType[CoordinateLike]
 
 
 class BaseContour(
@@ -685,7 +686,7 @@ class BaseContour(
     # Point and Contour Inside
     # ------------------------
 
-    def pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` is within the filled area of the contour.
 
         :param point: The point to check as a :ref:`type-coordinate`.
@@ -701,7 +702,7 @@ class BaseContour(
         point = normalizers.normalizeCoordinateTuple(point)
         return self._pointInside(point)
 
-    def _pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def _pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` is within the filled area of the native contour.
 
          This is the environment implementation of :meth:`BaseContour.pointInside`.
@@ -1283,9 +1284,9 @@ class BaseContour(
     def appendBPoint(
         self,
         type: str | None = None,
-        anchor: PairCollectionType[IntFloatType] | None = None,
-        bcpIn: PairCollectionType[IntFloatType] | None = None,
-        bcpOut: PairCollectionType[IntFloatType] | None = None,
+        anchor: CoordinateLike | None = None,
+        bcpIn: CoordinateLike | None = None,
+        bcpOut: CoordinateLike | None = None,
         bPoint: BaseBPoint | None = None,
     ) -> None:
         """Append the given bPoint to the contour.
@@ -1331,9 +1332,9 @@ class BaseContour(
     def _appendBPoint(
         self,
         type: str,
-        anchor: PairCollectionType[IntFloatType],
-        bcpIn: PairCollectionType[IntFloatType],
-        bcpOut: PairCollectionType[IntFloatType],
+        anchor: CoordinateLike,
+        bcpIn: CoordinateLike,
+        bcpOut: CoordinateLike,
         **kwargs: Any,
     ) -> None:
         r"""Append the given bPoint to the native contour.
@@ -1365,9 +1366,9 @@ class BaseContour(
         self,
         index: int,
         type: str | None = None,
-        anchor: PairCollectionType[IntFloatType] | None = None,
-        bcpIn: PairCollectionType[IntFloatType] | None = None,
-        bcpOut: PairCollectionType[IntFloatType] | None = None,
+        anchor: CoordinateLike | None = None,
+        bcpIn: CoordinateLike | None = None,
+        bcpOut: CoordinateLike | None = None,
         bPoint: BaseBPoint | None = None,
     ) -> None:
         """Insert the given bPoint into the contour.
@@ -1421,9 +1422,9 @@ class BaseContour(
         self,
         index: int,
         type: str,
-        anchor: PairCollectionType[IntFloatType],
-        bcpIn: PairCollectionType[IntFloatType],
-        bcpOut: PairCollectionType[IntFloatType],
+        anchor: CoordinateLike,
+        bcpIn: CoordinateLike,
+        bcpOut: CoordinateLike,
         **kwargs: Any,
     ) -> None:
         r"""Insert the given bPoint into the native contour.
@@ -1604,7 +1605,7 @@ class BaseContour(
 
     def appendPoint(
         self,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         type: str = "line",
         smooth: bool = False,
         name: str | None = None,
@@ -1652,7 +1653,7 @@ class BaseContour(
     def insertPoint(
         self,
         index: int,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         type: str = "line",
         smooth: bool = False,
         name: str | None = None,
@@ -1714,7 +1715,7 @@ class BaseContour(
     def _insertPoint(
         self,
         index: int,
-        position: PairCollectionType[IntFloatType],
+        position: CoordinateLike,
         type: str,
         smooth: bool,
         name: str | None,

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -1139,9 +1139,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     # new
 
-    def newLayer(
-        self, name: str, color: RGBALike | None = None
-    ) -> BaseLayer:
+    def newLayer(self, name: str, color: RGBALike | None = None) -> BaseLayer:
         """Create a new layer in the font.
 
         :param name: The name of the new layer to create.
@@ -1167,10 +1165,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return layer
 
     def _newLayer(  # type: ignore[return]
-        self,
-        name: str,
-        color: RGBALike | None,
-        **kwargs: Any,
+        self, name: str, color: RGBALike | None, **kwargs: Any
     ) -> BaseLayer:
         r"""Create a new layer in the native font.
 

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -11,6 +11,8 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import FontCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedFont, RemovedFont
 from fontParts.base.annotations import (
+    InterpolationFactorPair,
+    InterpolationFactorLike,
     RGBALike,
     RGBA,
     Coordinate,
@@ -18,7 +20,6 @@ from fontParts.base.annotations import (
     CharacterMappingType,
     CollectionType,
     IntFloatType,
-    TransformationType,
     KerningDictType,
     ReverseComponentMappingType,
 )
@@ -1933,7 +1934,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorLike,
         minFont: BaseFont,
         maxFont: BaseFont,
         round: bool = True,
@@ -1982,7 +1983,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def _interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorPair,
         minFont: BaseFont,
         maxFont: BaseFont,
         round: bool,

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -11,11 +11,12 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import FontCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedFont, RemovedFont
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     CharacterMappingType,
     CollectionType,
     IntFloatType,
     QuadrupleCollectionType,
-    PairCollectionType,
     TransformationType,
     KerningDictType,
     ReverseComponentMappingType,
@@ -1761,7 +1762,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def appendGuideline(
         self,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         angle: IntFloatType | None = None,
         name: str | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,
@@ -1832,7 +1833,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def _appendGuideline(  # type: ignore[return]
         self,
-        position: PairCollectionType[IntFloatType],
+        position: CoordinateLike,
         angle: float | None,
         name: str | None,
         color: QuadrupleCollectionType[IntFloatType] | None,

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -11,12 +11,13 @@ from fontParts.base import normalizers
 from fontParts.base.compatibility import FontCompatibilityReporter
 from fontParts.base.deprecated import DeprecatedFont, RemovedFont
 from fontParts.base.annotations import (
+    RGBALike,
+    RGBA,
     Coordinate,
     CoordinateLike,
     CharacterMappingType,
     CollectionType,
     IntFloatType,
-    QuadrupleCollectionType,
     TransformationType,
     KerningDictType,
     ReverseComponentMappingType,
@@ -1138,7 +1139,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     # new
 
     def newLayer(
-        self, name: str, color: QuadrupleCollectionType[IntFloatType] | None = None
+        self, name: str, color: RGBALike | None = None
     ) -> BaseLayer:
         """Create a new layer in the font.
 
@@ -1167,7 +1168,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     def _newLayer(  # type: ignore[return]
         self,
         name: str,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
         **kwargs: Any,
     ) -> BaseLayer:
         r"""Create a new layer in the native font.
@@ -1765,7 +1766,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         position: CoordinateLike | None = None,
         angle: IntFloatType | None = None,
         name: str | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         guideline: BaseGuideline | None = None,
     ) -> BaseGuideline:
         """Append a new guideline to the font.
@@ -1836,7 +1837,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         position: CoordinateLike,
         angle: float | None,
         name: str | None,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
         **kwargs: Any,
     ) -> BaseGuideline:
         r"""Append a new guideline to the native font.

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -28,16 +28,17 @@ from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
 from fontParts.base.annotations import (
+    InterpolationFactorLike,
+    InterpolationFactorPair,
+    ScaleFactorLike,
     AffineTransformationLike,
     BoundingBox,
     Coordinate,
     CoordinateLike,
-    PairCollectionType,
     RGBA,
     RGBALike,
     CollectionType,
     IntFloatType,
-    TransformationType,
     DiffType,
     PenType,
     PointPenType,
@@ -1482,7 +1483,7 @@ class BaseGlyph(
         self,
         baseGlyph: str | None = None,
         offset: CoordinateLike | None = None,
-        scale: TransformationType | None = None,
+        scale: ScaleFactorLike | None = None,
         component: BaseComponent | None = None,
     ) -> BaseComponent:
         """Append a component to the glyph.
@@ -2366,7 +2367,7 @@ class BaseGlyph(
 
     def scaleBy(
         self,
-        value: TransformationType,
+        value: ScaleFactorLike,
         origin: CoordinateLike | None = None,
         width: bool = False,
         height: bool = False,
@@ -2600,7 +2601,7 @@ class BaseGlyph(
         copied.note = mathGlyph.note
         return copied
 
-    def __mul__(self, factor: TransformationType) -> BaseGlyph:
+    def __mul__(self, factor: InterpolationFactorLike) -> BaseGlyph:
         """Multiply the current glyph by a given factor.
 
         :param factor: The factor by which to multiply the glyph as a
@@ -2623,7 +2624,7 @@ class BaseGlyph(
 
     __rmul__ = __mul__
 
-    def __truediv__(self, factor: TransformationType) -> BaseGlyph:
+    def __truediv__(self, factor: InterpolationFactorLike) -> BaseGlyph:
         """Divide the current glyph by a given factor.
 
         :param factor: The factor by which to divide the glyph as a
@@ -2690,7 +2691,7 @@ class BaseGlyph(
 
     def interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorLike,
         minGlyph: BaseGlyph,
         maxGlyph: BaseGlyph,
         round: bool = True,
@@ -2740,7 +2741,7 @@ class BaseGlyph(
 
     def _interpolate(
         self,
-        factor: PairCollectionType[IntFloatType],
+        factor: InterpolationFactorPair,
         minGlyph: BaseGlyph,
         maxGlyph: BaseGlyph,
         round: bool,
@@ -3270,7 +3271,7 @@ class BaseGlyph(
         self,
         path: str | None = None,
         data: bytes | None = None,
-        scale: TransformationType | None = None,
+        scale: ScaleFactorLike | None = None,
         position: CoordinateLike | None = None,
         color: RGBALike | None = None,
     ) -> BaseImage:

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -28,6 +28,7 @@ from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     BoundingBox,
     Coordinate,
     CoordinateLike,
@@ -35,7 +36,6 @@ from fontParts.base.annotations import (
     RGBA,
     RGBALike,
     CollectionType,
-    SextupleCollectionType,
     IntFloatType,
     TransformationType,
     DiffType,
@@ -1559,7 +1559,7 @@ class BaseGlyph(
     def _appendComponent(
         self,
         baseGlyph: str,
-        transformation: SextupleCollectionType[IntFloatType] | None,
+        transformation: AffineTransformationLike | None,
         identifier: str | None,
         **kwargs: Any,
     ) -> BaseComponent:
@@ -2343,7 +2343,7 @@ class BaseGlyph(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the glyph according to the given matrix.
 
@@ -3345,7 +3345,7 @@ class BaseGlyph(
     def _addImage(
         self,  # type: ignore[return]
         data: bytes,
-        transformation: SextupleCollectionType[IntFloatType] | None,
+        transformation: AffineTransformationLike | None,
         color: RGBALike | None,
     ) -> BaseImage:
         """Set the image in the native glyph.

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -1075,9 +1075,7 @@ class BaseGlyph(
         normalizedOffset = normalizers.normalizeTransformationOffset(offset)
         self._appendGlyph(other, normalizedOffset)
 
-    def _appendGlyph(
-        self, other: BaseGlyph, offset: CoordinateLike
-    ) -> None:
+    def _appendGlyph(self, other: BaseGlyph, offset: CoordinateLike) -> None:
         """Append data from `other` to new objects in the native glyph.
 
         This is the environment implementation of :meth:`BaseGlyph.appendGlyph`.
@@ -1239,9 +1237,7 @@ class BaseGlyph(
         raise FontPartsError("The contour could not be found.")
 
     def appendContour(
-        self,
-        contour: BaseContour,
-        offset: CoordinateLike | None = None,
+        self, contour: BaseContour, offset: CoordinateLike | None = None
     ) -> BaseContour:
         """Append the given contour's data to the glyph.
 
@@ -1265,10 +1261,7 @@ class BaseGlyph(
         return self._appendContour(normalizedContour, normalizedOffset)
 
     def _appendContour(
-        self,
-        contour: BaseContour,
-        offset: CoordinateLike,
-        **kwargs: Any,
+        self, contour: BaseContour, offset: CoordinateLike, **kwargs: Any
     ) -> BaseContour:
         r"""Append the given contour's data to the native glyph.
 
@@ -2343,9 +2336,7 @@ class BaseGlyph(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the glyph according to the given matrix.
 
         :param matrix: The :ref:`type-transformation` to apply.
@@ -3419,9 +3410,7 @@ class BaseGlyph(
             return None
         return Color(value)
 
-    def _set_base_markColor(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_base_markColor(self, value: RGBALike | None) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_markColor(value)
@@ -3445,9 +3434,7 @@ class BaseGlyph(
         """
         self.raiseNotImplementedError()
 
-    def _set_markColor(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_markColor(self, value: RGBALike | None) -> None:
         """Set the glyph's mark color.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -28,6 +28,7 @@ from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
 from fontParts.base.annotations import (
+    BoundingBox,
     Coordinate,
     CoordinateLike,
     PairCollectionType,
@@ -3001,13 +3002,13 @@ class BaseGlyph(
         """,
     )
 
-    def _get_base_bounds(self) -> QuadrupleType[float] | None:
+    def _get_base_bounds(self) -> BoundingBox | None:
         value = self._get_bounds()
         if value is not None:
             value = normalizers.normalizeBoundingBox(value)
         return value
 
-    def _get_bounds(self) -> QuadrupleType[float] | None:
+    def _get_bounds(self) -> BoundingBox | None:
         """Get the bounds of the native glyph.
 
         This is the environment implementation of the :attr:`BaseGlyph.bounds`

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -32,9 +32,9 @@ from fontParts.base.annotations import (
     Coordinate,
     CoordinateLike,
     PairCollectionType,
-    QuadrupleType,
+    RGBA,
+    RGBALike,
     CollectionType,
-    QuadrupleCollectionType,
     SextupleCollectionType,
     IntFloatType,
     TransformationType,
@@ -1759,7 +1759,7 @@ class BaseGlyph(
         self,
         name: str | None = None,
         position: CoordinateLike | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         anchor: BaseAnchor | None = None,
     ) -> BaseAnchor:
         """Append an anchor to the glyph.
@@ -1815,7 +1815,7 @@ class BaseGlyph(
         self,  # type: ignore[return]
         name: str,
         position: CoordinateLike | None,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
         identifier: str | None,
         **kwargs: Any,
     ) -> BaseAnchor:
@@ -2004,7 +2004,7 @@ class BaseGlyph(
         position: CoordinateLike | None = None,
         angle: IntFloatType | None = None,
         name: str | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         guideline: BaseGuideline | None = None,
     ) -> BaseGuideline:
         """Append a guideline to the glyph.
@@ -2075,7 +2075,7 @@ class BaseGlyph(
         position: CoordinateLike,
         angle: IntFloatType,
         name: str | None,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
         identifier: str | None,
         **kwargs: Any,
     ) -> BaseGuideline:
@@ -3272,7 +3272,7 @@ class BaseGlyph(
         data: bytes | None = None,
         scale: TransformationType | None = None,
         position: CoordinateLike | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
     ) -> BaseImage:
         """Set the image in the glyph.
 
@@ -3346,7 +3346,7 @@ class BaseGlyph(
         self,  # type: ignore[return]
         data: bytes,
         transformation: SextupleCollectionType[IntFloatType] | None,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
     ) -> BaseImage:
         """Set the image in the native glyph.
 
@@ -3419,14 +3419,14 @@ class BaseGlyph(
         return Color(value)
 
     def _set_base_markColor(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_markColor(value)
 
     # type: ignore[return]
-    def _get_markColor(self) -> QuadrupleType[float] | None:
+    def _get_markColor(self) -> RGBA | None:
         """Get the glyph's mark color.
 
         This is the environment implementation of
@@ -3445,7 +3445,7 @@ class BaseGlyph(
         self.raiseNotImplementedError()
 
     def _set_markColor(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         """Set the glyph's mark color.
 

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -28,10 +28,11 @@ from fontParts.base.compatibility import GlyphCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGlyph, RemovedGlyph
 from fontParts.base.annotations import (
-    PairType,
+    Coordinate,
+    CoordinateLike,
+    PairCollectionType,
     QuadrupleType,
     CollectionType,
-    PairCollectionType,
     QuadrupleCollectionType,
     SextupleCollectionType,
     IntFloatType,
@@ -1044,7 +1045,7 @@ class BaseGlyph(
             self.clearImage()
 
     def appendGlyph(
-        self, other: BaseGlyph, offset: PairCollectionType[IntFloatType] | None = None
+        self, other: BaseGlyph, offset: CoordinateLike | None = None
     ) -> None:
         """Append data from `other` to new objects in the glyph.
 
@@ -1073,7 +1074,7 @@ class BaseGlyph(
         self._appendGlyph(other, normalizedOffset)
 
     def _appendGlyph(
-        self, other: BaseGlyph, offset: PairCollectionType[IntFloatType]
+        self, other: BaseGlyph, offset: CoordinateLike
     ) -> None:
         """Append data from `other` to new objects in the native glyph.
 
@@ -1238,7 +1239,7 @@ class BaseGlyph(
     def appendContour(
         self,
         contour: BaseContour,
-        offset: PairCollectionType[IntFloatType] | None = None,
+        offset: CoordinateLike | None = None,
     ) -> BaseContour:
         """Append the given contour's data to the glyph.
 
@@ -1264,7 +1265,7 @@ class BaseGlyph(
     def _appendContour(
         self,
         contour: BaseContour,
-        offset: PairCollectionType[IntFloatType],
+        offset: CoordinateLike,
         **kwargs: Any,
     ) -> BaseContour:
         r"""Append the given contour's data to the native glyph.
@@ -1479,7 +1480,7 @@ class BaseGlyph(
     def appendComponent(
         self,
         baseGlyph: str | None = None,
-        offset: PairCollectionType[IntFloatType] | None = None,
+        offset: CoordinateLike | None = None,
         scale: TransformationType | None = None,
         component: BaseComponent | None = None,
     ) -> BaseComponent:
@@ -1756,7 +1757,7 @@ class BaseGlyph(
     def appendAnchor(
         self,
         name: str | None = None,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,
         anchor: BaseAnchor | None = None,
     ) -> BaseAnchor:
@@ -1812,7 +1813,7 @@ class BaseGlyph(
     def _appendAnchor(
         self,  # type: ignore[return]
         name: str,
-        position: PairCollectionType[IntFloatType] | None,
+        position: CoordinateLike | None,
         color: QuadrupleCollectionType[IntFloatType] | None,
         identifier: str | None,
         **kwargs: Any,
@@ -1999,7 +2000,7 @@ class BaseGlyph(
 
     def appendGuideline(
         self,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         angle: IntFloatType | None = None,
         name: str | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,
@@ -2070,7 +2071,7 @@ class BaseGlyph(
 
     def _appendGuideline(
         self,  # type: ignore[return]
-        position: PairCollectionType[IntFloatType],
+        position: CoordinateLike,
         angle: IntFloatType,
         name: str | None,
         color: QuadrupleCollectionType[IntFloatType] | None,
@@ -2365,7 +2366,7 @@ class BaseGlyph(
     def scaleBy(
         self,
         value: TransformationType,
-        origin: PairCollectionType[IntFloatType] | None = None,
+        origin: CoordinateLike | None = None,
         width: bool = False,
         height: bool = False,
     ) -> None:
@@ -2947,7 +2948,7 @@ class BaseGlyph(
     # Data Queries
     # ------------
 
-    def pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` lies inside the filled area of the glyph.
 
         :param point: The point to check as a :ref:`type-coordinate`.
@@ -2963,7 +2964,7 @@ class BaseGlyph(
         point = normalizers.normalizeCoordinateTuple(point)
         return self._pointInside(point)
 
-    def _pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def _pointInside(self, point: CoordinateLike) -> bool:
         """Check if `point` lies inside the filled area of the native glyph.
 
         This is the environment implementation of :meth:`BaseGlyph.pointInside`.
@@ -3269,7 +3270,7 @@ class BaseGlyph(
         path: str | None = None,
         data: bytes | None = None,
         scale: TransformationType | None = None,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,
     ) -> BaseImage:
         """Set the image in the glyph.

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -18,9 +18,9 @@ from fontParts.base.compatibility import GuidelineCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGuideline, RemovedGuideline
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     RGBALike,
     RGBA,
-    SextupleCollectionType,
     IntFloatType,
 )
 
@@ -587,7 +587,7 @@ class BaseGuideline(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native guideline according to the given matrix.
 

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -18,8 +18,8 @@ from fontParts.base.compatibility import GuidelineCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedGuideline, RemovedGuideline
 from fontParts.base.annotations import (
-    QuadrupleType,
-    QuadrupleCollectionType,
+    RGBALike,
+    RGBA,
     SextupleCollectionType,
     IntFloatType,
 )
@@ -532,20 +532,20 @@ class BaseGuideline(
         """,
     )
 
-    def _get_base_color(self) -> QuadrupleType[float] | None:
+    def _get_base_color(self) -> RGBA | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
         return value
 
     def _set_base_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         """Get the native guideline's color.
 
         This is the environment implementation of the :attr:`BaseGuideline.color`
@@ -564,7 +564,7 @@ class BaseGuideline(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         """Set the native guideline's color.
 
         This is the environment implementation of the :attr:`BaseGuideline.color`

--- a/Lib/fontParts/base/guideline.py
+++ b/Lib/fontParts/base/guideline.py
@@ -538,9 +538,7 @@ class BaseGuideline(
             value = Color(value)
         return value
 
-    def _set_base_color(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_base_color(self, value: RGBALike | None) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
@@ -586,9 +584,7 @@ class BaseGuideline(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native guideline according to the given matrix.
 
         This is the environment implementation of :meth:`BaseGuideline.transformBy`.

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -14,16 +14,16 @@ from fontParts.base import normalizers
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedImage, RemovedImage
 from fontParts.base.annotations import (
+    ScaleFactorLike,
+    ScaleFactorPair,
+    ScaleFactor,
     AffineTransformationLike,
     AffineTransformation,
     Coordinate,
     CoordinateLike,
-    PairCollectionType,
-    PairType,
     RGBA,
     RGBALike,
     IntFloatType,
-    TransformationType,
 )
 
 if TYPE_CHECKING:
@@ -295,16 +295,16 @@ class BaseImage(
         """,
     )
 
-    def _get_base_scale(self) -> PairType[float]:
+    def _get_base_scale(self) -> ScaleFactor:
         value = self._get_scale()
         value = normalizers.normalizeTransformationScale(value)
         return value
 
-    def _set_base_scale(self, value: TransformationType) -> None:
+    def _set_base_scale(self, value: ScaleFactorLike) -> None:
         value = normalizers.normalizeTransformationScale(value)
         self._set_scale(value)
 
-    def _get_scale(self) -> PairType[float]:
+    def _get_scale(self) -> ScaleFactor:
         """Get the native image's scale.
 
         This is the environment implementation of the :attr:`BaseImage.scale`
@@ -322,7 +322,7 @@ class BaseImage(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return (sx, sy)
 
-    def _set_scale(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_scale(self, value: ScaleFactorPair) -> None:
         """Set the native image's scale.
 
         This is the environment implementation of the :attr:`BaseImage.scale`

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -171,9 +171,7 @@ class BaseImage(
         value = normalizers.normalizeTransformationMatrix(value)
         return value
 
-    def _set_base_transformation(
-        self, value: AffineTransformationLike
-    ) -> None:
+    def _set_base_transformation(self, value: AffineTransformationLike) -> None:
         value = normalizers.normalizeTransformationMatrix(value)
         self._set_transformation(value)
 
@@ -368,9 +366,7 @@ class BaseImage(
             value = Color(value)
         return value
 
-    def _set_base_color(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_base_color(self, value: RGBALike | None) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
@@ -472,9 +468,7 @@ class BaseImage(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native image.
 
         This is the environment implementation of :meth:`BaseImage.transformBy`.

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -14,14 +14,14 @@ from fontParts.base import normalizers
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedImage, RemovedImage
 from fontParts.base.annotations import (
+    AffineTransformationLike,
+    AffineTransformation,
     Coordinate,
     CoordinateLike,
     PairCollectionType,
     PairType,
     RGBA,
     RGBALike,
-    SextupleType,
-    SextupleCollectionType,
     IntFloatType,
     TransformationType,
 )
@@ -166,18 +166,18 @@ class BaseImage(
         """,
     )
 
-    def _get_base_transformation(self) -> SextupleType[float]:
+    def _get_base_transformation(self) -> AffineTransformation:
         value = self._get_transformation()
         value = normalizers.normalizeTransformationMatrix(value)
         return value
 
     def _set_base_transformation(
-        self, value: SextupleCollectionType[IntFloatType]
+        self, value: AffineTransformationLike
     ) -> None:
         value = normalizers.normalizeTransformationMatrix(value)
         self._set_transformation(value)
 
-    def _get_transformation(self) -> SextupleType[float]:
+    def _get_transformation(self) -> AffineTransformation:
         """Get the native image's transformation matrix.
 
         This is the environment implementation of the
@@ -196,7 +196,7 @@ class BaseImage(
         """
         self.raiseNotImplementedError()
 
-    def _set_transformation(self, value: SextupleCollectionType[IntFloatType]) -> None:
+    def _set_transformation(self, value: AffineTransformationLike) -> None:
         """Set the native image's transformation matrix.
 
         This is the environment implementation of the
@@ -473,7 +473,7 @@ class BaseImage(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native image.
 

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -14,8 +14,10 @@ from fontParts.base import normalizers
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedImage, RemovedImage
 from fontParts.base.annotations import (
-    PairType,
+    Coordinate,
+    CoordinateLike,
     PairCollectionType,
+    PairType,
     QuadrupleType,
     QuadrupleCollectionType,
     SextupleType,
@@ -229,16 +231,16 @@ class BaseImage(
         """,
     )
 
-    def _get_base_offset(self) -> PairType[IntFloatType]:
+    def _get_base_offset(self) -> Coordinate:
         value = self._get_offset()
         value = normalizers.normalizeTransformationOffset(value)
         return value
 
-    def _set_base_offset(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_base_offset(self, value: CoordinateLike) -> None:
         value = normalizers.normalizeTransformationOffset(value)
         self._set_offset(value)
 
-    def _get_offset(self) -> PairType[IntFloatType]:
+    def _get_offset(self) -> Coordinate:
         """Get the native image's offset.
 
         This is the environment implementation of the :attr:`BaseImage.offset`
@@ -256,7 +258,7 @@ class BaseImage(
         sx, sxy, syx, sy, ox, oy = self.transformation
         return (ox, oy)
 
-    def _set_offset(self, value: PairCollectionType[IntFloatType]) -> None:
+    def _set_offset(self, value: CoordinateLike) -> None:
         """Set the native image's offset.
 
         This is the environment implementation of the :attr:`BaseImage.offset`

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -18,8 +18,8 @@ from fontParts.base.annotations import (
     CoordinateLike,
     PairCollectionType,
     PairType,
-    QuadrupleType,
-    QuadrupleCollectionType,
+    RGBA,
+    RGBALike,
     SextupleType,
     SextupleCollectionType,
     IntFloatType,
@@ -369,13 +369,13 @@ class BaseImage(
         return value
 
     def _set_base_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         """Get the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`
@@ -394,7 +394,7 @@ class BaseImage(
         """
         self.raiseNotImplementedError()
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         """Set the native image's color.
 
         This is the environment implementation of the :attr:`BaseImage.color`

--- a/Lib/fontParts/base/info.py
+++ b/Lib/fontParts/base/info.py
@@ -11,7 +11,7 @@ from fontParts.base.base import BaseObject, dynamicProperty, interpolate, refere
 from fontParts.base import normalizers
 from fontParts.base.errors import FontPartsError
 from fontParts.base.deprecated import DeprecatedInfo, RemovedInfo
-from fontParts.base.annotations import TransformationType
+from fontParts.base.annotations import InterpolationFactorPair, InterpolationFactorLike
 
 if TYPE_CHECKING:
     from fontParts.base.font import BaseFont
@@ -836,7 +836,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
 
     def interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorLike,
         minInfo: BaseInfo,
         maxInfo: BaseInfo,
         round: bool = True,
@@ -884,7 +884,7 @@ class BaseInfo(BaseObject, DeprecatedInfo, RemovedInfo):
 
     def _interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorPair,
         minInfo: BaseInfo,
         maxInfo: BaseInfo,
         round: bool = True,

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -6,13 +6,15 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
+    InterpolationFactorLike,
+    InterpolationFactorPair,
+    ScaleFactorLike,
+    ScaleFactorPair,
     KerningPairLike,
     KerningPair,
     Coordinate,
     CoordinateLike,
     IntFloatType,
-    PairCollectionType,
-    TransformationType,
 )
 from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
 from fontParts.base.deprecated import DeprecatedKerning, RemovedKerning
@@ -100,7 +102,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
     # Transformation
     # --------------
 
-    def scaleBy(self, factor: TransformationType) -> None:
+    def scaleBy(self, factor: ScaleFactorLike) -> None:
         """Scale all kerning values by the specified factor.
 
         :param factor: The factor by which to scale the kerning. The value may be a
@@ -118,7 +120,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         factor = normalizers.normalizeTransformationScale(factor)
         self._scale(factor)
 
-    def _scale(self, factor: PairCollectionType[IntFloatType]) -> None:
+    def _scale(self, factor: ScaleFactorPair) -> None:
         """Scale all native kerning values by the specified factor.
 
         This is the environment implementation of :meth:`BaseKerning.scaleBy`.
@@ -184,7 +186,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     def interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorLike,
         minKerning: BaseKerningType,
         maxKerning: BaseKerningType,
         round: bool = True,
@@ -232,7 +234,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     def _interpolate(
         self,
-        factor: PairCollectionType[IntFloatType],
+        factor: InterpolationFactorPair,
         minKerning: BaseKerning,
         maxKerning: BaseKerning,
         round: bool,

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
+    KerningPairLike,
+    KerningPair,
     Coordinate,
     CoordinateLike,
     IntFloatType,
     PairCollectionType,
-    PairType,
     TransformationType,
 )
 from fontParts.base.base import BaseDict, dynamicProperty, interpolate, reference
@@ -43,7 +44,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
 
     """
 
-    keyNormalizer: Callable[[PairCollectionType[str]], PairType[str]] = (
+    keyNormalizer: Callable[[KerningPairLike], KerningPair] = (
         normalizers.normalizeKerningKey
     )
     valueNormalizer: Callable[[IntFloatType], IntFloatType] = (
@@ -313,7 +314,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
     # RoboFab Compatibility
     # ---------------------
 
-    def remove(self, pair: PairCollectionType[str]) -> None:
+    def remove(self, pair: KerningPairLike) -> None:
         """Remove the specified pair from the Kerning.
 
         :param pair: The pair to remove as a :class:`tuple` of two :class:`str` values.
@@ -327,10 +328,9 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
             >>> myKerning.remove(("A", "V"))
 
         """
-        one, two = pair
-        del self[(one, two)]
+        del self[pair]
 
-    def asDict(self, returnIntegers: bool = True) -> dict[PairType[str], IntFloatType]:
+    def asDict(self, returnIntegers: bool = True) -> dict[KerningPair, IntFloatType]:
         """Return the kerning as a dictionary.
 
         :return A :class:`dict` reflecting the contents of the kerning.
@@ -353,7 +353,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
     # Inherited Functions
     # -------------------
 
-    def __contains__(self, pair: PairType[str]) -> bool:
+    def __contains__(self, pair: KerningPairLike) -> bool:
         """Check if the given pair exists in the kerning.
 
         :param pair: The kerning pair to check for existence as a :class:`tuple` of
@@ -369,7 +369,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         return super().__contains__(pair)
 
-    def __delitem__(self, pair: PairType[str]) -> None:
+    def __delitem__(self, pair: KerningPairLike) -> None:
         """Remove the given pair from the kerning.
 
         :param pair: The pair to remove as a :class:`tuple` of two :class:`str` values.
@@ -381,7 +381,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         super().__delitem__(pair)
 
-    def __getitem__(self, pair: PairType[str]) -> IntFloatType:
+    def __getitem__(self, pair: KerningPairLike) -> IntFloatType:
         """Get the value associated with the given kerning pair.
 
         :param pair: The pair to remove as a :class:`tuple` of two :class:`str` values.
@@ -405,7 +405,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         return super().__getitem__(pair)
 
-    def __iter__(self) -> Iterator[PairType[str]]:
+    def __iter__(self) -> Iterator[KerningPair]:
         """Return an iterator over the pairs in the kerning.
 
         The iteration order is not fixed.
@@ -437,7 +437,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         return super().__len__()
 
-    def __setitem__(self, pair: PairType[str], value: IntFloatType) -> None:
+    def __setitem__(self, pair: KerningPairLike, value: IntFloatType) -> None:
         """Set the value for the given kerning pair.
 
         :param pair: The pair to set as a :class:`tuple` of two :class:`str` values.
@@ -464,7 +464,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         super().clear()
 
     def get(
-        self, pair: PairCollectionType[str], default: IntFloatType | None = None
+        self, pair: KerningPairLike, default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Get the value for the given kerning pair.
 
@@ -494,7 +494,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return super().get(pair, default)
 
     def find(
-        self, pair: PairCollectionType[str], default: IntFloatType | None = None
+        self, pair: KerningPairLike, default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Get the value for the given explicit or implicit kerning pair.
 
@@ -520,7 +520,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return value
 
     def _find(
-        self, pair: PairCollectionType[str], default: IntFloatType | None = None
+        self, pair: KerningPairLike, default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Get the value for the given explicit or implicit native kerning pair.
 
@@ -542,7 +542,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         groups = font.groups
         return lookupKerningValue(pair, self, groups, fallback=default)
 
-    def items(self) -> BaseItems[PairType[str], IntFloatType]:
+    def items(self) -> BaseItems[KerningPair, IntFloatType]:
         """Return the kerning's items.
 
         Each item is represented as a :class:`tuple` of key-value pairs, where:
@@ -559,7 +559,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         return super().items()
 
-    def keys(self) -> BaseKeys[PairType[str]]:
+    def keys(self) -> BaseKeys[KerningPair]:
         """Return the kerning's pairs (keys).
 
         :return: A :ref:`type-view` of the kerning's pairs as :class:`tuple` instances
@@ -587,7 +587,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         return super().values()
 
     def pop(
-        self, pair: PairType[str], default: IntFloatType | None = None
+        self, pair: KerningPairLike, default: IntFloatType | None = None
     ) -> IntFloatType | None:
         """Remove the specified kerning pair and return its associated value.
 
@@ -610,7 +610,7 @@ class BaseKerning(BaseDict, DeprecatedKerning, RemovedKerning):
         """
         return super().pop(pair, default)
 
-    def update(self, otherKerning: MutableMapping[PairType[str], IntFloatType]) -> None:
+    def update(self, otherKerning: MutableMapping[KerningPair, IntFloatType]) -> None:
         """Update the current kerning with key-value pairs from another.
 
         For each pair in `otherKerning`:

--- a/Lib/fontParts/base/kerning.py
+++ b/Lib/fontParts/base/kerning.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar, Union
 
 from fontParts.base import normalizers
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     IntFloatType,
     PairCollectionType,
     PairType,

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -17,10 +17,10 @@ from fontParts.base.compatibility import LayerCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedLayer, RemovedLayer
 from fontParts.base.annotations import (
+    RGBALike,
+    RGBA,
     CharacterMappingType,
     CollectionType,
-    QuadrupleCollectionType,
-    QuadrupleType,
     TransformationType,
     ReverseComponentMappingType,
     IntFloatType,
@@ -833,20 +833,20 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         """,
     )
 
-    def _get_base_color(self) -> QuadrupleCollectionType[IntFloatType] | None:
+    def _get_base_color(self) -> Color | None:
         value = self._get_color()
         if value is not None:
             value = Color(value)
         return value
 
     def _set_base_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
 
-    def _get_color(self) -> QuadrupleType[float] | None:  # type: ignore[return]
+    def _get_color(self) -> RGBA | None:  # type: ignore[return]
         """Get the color of the layer.
 
         This is the environment implementation of
@@ -866,7 +866,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         self.raiseNotImplementedError()
 
     def _set_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None, **kwargs: Any
+        self, value: RGBALike | None, **kwargs: Any
     ) -> None:
         r"""Get or set the color of the layer.
 

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -840,9 +840,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
             value = Color(value)
         return value
 
-    def _set_base_color(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_base_color(self, value: RGBALike | None) -> None:
         if value is not None:
             value = normalizers.normalizeColor(value)
         self._set_color(value)
@@ -866,9 +864,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
         """
         self.raiseNotImplementedError()
 
-    def _set_color(
-        self, value: RGBALike | None, **kwargs: Any
-    ) -> None:
+    def _set_color(self, value: RGBALike | None, **kwargs: Any) -> None:
         r"""Get or set the color of the layer.
 
         This is the environment implementation of

--- a/Lib/fontParts/base/layer.py
+++ b/Lib/fontParts/base/layer.py
@@ -17,11 +17,12 @@ from fontParts.base.compatibility import LayerCompatibilityReporter
 from fontParts.base.color import Color
 from fontParts.base.deprecated import DeprecatedLayer, RemovedLayer
 from fontParts.base.annotations import (
+    InterpolationFactorPair,
+    InterpolationFactorLike,
     RGBALike,
     RGBA,
     CharacterMappingType,
     CollectionType,
-    TransformationType,
     ReverseComponentMappingType,
     IntFloatType,
 )
@@ -1035,7 +1036,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
     def interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorLike,
         minLayer: BaseLayer,
         maxLayer: BaseLayer,
         round: bool = True,
@@ -1084,7 +1085,7 @@ class BaseLayer(_BaseGlyphVendor, InterpolationMixin, DeprecatedLayer, RemovedLa
 
     def _interpolate(
         self,
-        factor: TransformationType,
+        factor: InterpolationFactorPair,
         minLayer: BaseLayer,
         maxLayer: BaseLayer,
         round: bool,

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import datetime
 
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     T,
     PairType,
     QuadrupleType,
@@ -991,8 +993,8 @@ def normalizeY(value: IntFloatType) -> IntFloatType:
 
 
 def normalizeCoordinateTuple(
-    value: PairCollectionType[IntFloatType],
-) -> PairType[IntFloatType]:
+    value: CoordinateLike,
+) -> Coordinate:
     """Normalize a coordinate tuple.
 
     :param value: The coordinate tuple to normalize as a :class:`list`
@@ -1253,8 +1255,8 @@ def normalizeTransformationMatrix(
 
 
 def normalizeTransformationOffset(
-    value: PairCollectionType[IntFloatType],
-) -> PairType[IntFloatType]:
+    value: CoordinateLike,
+) -> Coordinate:
     """Normalize a transformation offset.
 
     :param value: The transformation offset to normalize as a :class:`list`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -11,13 +11,13 @@ from fontParts.base.annotations import (
     BoundingBoxLike,
     Coordinate,
     CoordinateLike,
+    RGBA,
+    RGBALike,
     T,
     PairType,
-    QuadrupleType,
     SextupleType,
     CollectionType,
     PairCollectionType,
-    QuadrupleCollectionType,
     SextupleCollectionType,
     IntFloatType,
     TransformationType,
@@ -1108,8 +1108,8 @@ def normalizeRotationAngle(value: IntFloatType) -> float:
 
 
 def normalizeColor(
-    value: QuadrupleCollectionType[IntFloatType],
-) -> QuadrupleType[float]:
+    value: RGBALike,
+) -> RGBA:
     """Normalize a color.
 
     :param value: The color to normalize as a :class:`list` or :class:`tuple`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -7,6 +7,13 @@ from pathlib import Path
 import datetime
 
 from fontParts.base.annotations import (
+    InterpolationFactorLike,
+    InterpolationFactor,
+    SkewAngleLike,
+    SkewAngle,
+    ScaleFactorLike,
+    ScaleFactorPair,
+    ScaleFactor,
     KerningPairLike,
     KerningPair,
     AffineTransformationLike,
@@ -18,11 +25,8 @@ from fontParts.base.annotations import (
     RGBA,
     RGBALike,
     T,
-    PairType,
     CollectionType,
-    PairCollectionType,
     IntFloatType,
-    TransformationType,
     LibValueType,
 )
 
@@ -776,7 +780,7 @@ def normalizeComponent(value: BaseComponent) -> BaseComponent:
     return normalizeInternalObjectType(value, BaseComponent, "Component")
 
 
-def normalizeComponentScale(value: PairCollectionType[IntFloatType]) -> PairType[float]:
+def normalizeComponentScale(value: ScaleFactorPair) -> ScaleFactor:
     """Normalize a component scale.
 
     :param value: The component scale to normalize as a :class:`list`
@@ -1185,7 +1189,7 @@ def normalizeFilePath(value: str | Path) -> str:
 # Interpolation
 
 
-def normalizeInterpolationFactor(value: TransformationType) -> PairType[float]:
+def normalizeInterpolationFactor(value: InterpolationFactorLike) -> InterpolationFactor:
     """Normalize an interpolation factor.
 
     :param value: The interpolation factor to normalize as a single :class:`int`
@@ -1276,7 +1280,7 @@ def normalizeTransformationOffset(
     return normalizeCoordinateTuple(value)
 
 
-def normalizeTransformationSkewAngle(value: TransformationType) -> PairType[float]:
+def normalizeTransformationSkewAngle(value: SkewAngleLike) -> SkewAngle:
     """Normalize a transformation skew angle.
 
     :param value: The skew angle to normalize as a single :class:`int`
@@ -1321,7 +1325,7 @@ def normalizeTransformationSkewAngle(value: TransformationType) -> PairType[floa
     return (normalized[0], normalized[1])
 
 
-def normalizeTransformationScale(value: TransformationType) -> PairType[float]:
+def normalizeTransformationScale(value: ScaleFactorLike) -> ScaleFactor:
     """Normalize a transformation scale.
 
     :param value: The scale to normalize as a single :class:`int`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -1000,9 +1000,7 @@ def normalizeY(value: IntFloatType) -> IntFloatType:
     return value
 
 
-def normalizeCoordinateTuple(
-    value: CoordinateLike,
-) -> Coordinate:
+def normalizeCoordinateTuple(value: CoordinateLike) -> Coordinate:
     """Normalize a coordinate tuple.
 
     :param value: The coordinate tuple to normalize as a :class:`list`
@@ -1027,9 +1025,7 @@ def normalizeCoordinateTuple(
     return (x, y)
 
 
-def normalizeBoundingBox(
-    value: BoundingBoxLike,
-) -> BoundingBox:
+def normalizeBoundingBox(value: BoundingBoxLike) -> BoundingBox:
     """Normalize a bounding box.
 
     :param value: The bounding box to normalize as a :class:`list`
@@ -1113,9 +1109,7 @@ def normalizeRotationAngle(value: IntFloatType) -> float:
 # Color
 
 
-def normalizeColor(
-    value: RGBALike,
-) -> RGBA:
+def normalizeColor(value: RGBALike) -> RGBA:
     """Normalize a color.
 
     :param value: The color to normalize as a :class:`list` or :class:`tuple`
@@ -1262,9 +1256,7 @@ def normalizeTransformationMatrix(
     return (float(a), float(b), float(c), float(d), float(e), float(f))
 
 
-def normalizeTransformationOffset(
-    value: CoordinateLike,
-) -> Coordinate:
+def normalizeTransformationOffset(value: CoordinateLike) -> Coordinate:
     """Normalize a transformation offset.
 
     :param value: The transformation offset to normalize as a :class:`list`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import datetime
 
 from fontParts.base.annotations import (
+    BoundingBox,
+    BoundingBoxLike,
     Coordinate,
     CoordinateLike,
     T,
@@ -1020,8 +1022,8 @@ def normalizeCoordinateTuple(
 
 
 def normalizeBoundingBox(
-    value: QuadrupleCollectionType[IntFloatType],
-) -> QuadrupleType[float]:
+    value: BoundingBoxLike,
+) -> BoundingBox:
     """Normalize a bounding box.
 
     :param value: The bounding box to normalize as a :class:`list`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import datetime
 
 from fontParts.base.annotations import (
+    KerningPairLike,
+    KerningPair,
     AffineTransformationLike,
     AffineTransformation,
     BoundingBox,
@@ -163,7 +165,7 @@ def normalizeGlyphOrder(value: CollectionType[str]) -> tuple[str, ...]:
 # -------
 
 
-def normalizeKerningKey(value: PairCollectionType[str]) -> PairType[str]:
+def normalizeKerningKey(value: KerningPairLike) -> KerningPair:
     """Normalize a kerning key.
 
     :param value: The kerning key to normalize as a :class:`tuple`

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import datetime
 
 from fontParts.base.annotations import (
+    AffineTransformationLike,
+    AffineTransformation,
     BoundingBox,
     BoundingBoxLike,
     Coordinate,
@@ -15,10 +17,8 @@ from fontParts.base.annotations import (
     RGBALike,
     T,
     PairType,
-    SextupleType,
     CollectionType,
     PairCollectionType,
-    SextupleCollectionType,
     IntFloatType,
     TransformationType,
     LibValueType,
@@ -1225,8 +1225,8 @@ def normalizeInterpolationFactor(value: TransformationType) -> PairType[float]:
 
 
 def normalizeTransformationMatrix(
-    value: SextupleCollectionType[IntFloatType],
-) -> SextupleType[float]:
+    value: AffineTransformationLike,
+) -> AffineTransformation:
     """Normalize a transformation matrix.
 
     :param value: The transformation matrix to normalize as a :class:`list`

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -1,30 +1,28 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Any, Optional, Union, Tuple
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from fontTools.misc import transform
+
+from fontParts.base import normalizers
+from fontParts.base.annotations import AffineTransformationLike, IntFloatType
 from fontParts.base.base import (
     BaseObject,
-    TransformationMixin,
+    IdentifierMixin,
     PointPositionMixin,
     SelectionMixin,
-    IdentifierMixin,
+    TransformationMixin,
     dynamicProperty,
     reference,
 )
-from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
-from fontParts.base.annotations import (
-    AffineTransformationLike,
-    QuintupleType,
-    IntFloatType,
-)
 
 if TYPE_CHECKING:
+    from fontParts.base.contour import BaseContour
     from fontParts.base.font import BaseFont
     from fontParts.base.glyph import BaseGlyph
     from fontParts.base.lib import BaseLib
-    from fontParts.base.contour import BaseContour
 
 
 class BasePoint(
@@ -48,7 +46,13 @@ class BasePoint(
 
     """
 
-    copyAttributes: QuintupleType[str] = ("type", "smooth", "x", "y", "name")
+    copyAttributes: tuple[str, str, str, str, str] = (
+        "type",
+        "smooth",
+        "x",
+        "y",
+        "name",
+    )
 
     def _reprContents(self) -> list[str]:
         contents = [f"{self.type}", f"({self.x}, {self.y})"]
@@ -564,9 +568,7 @@ class BasePoint(
     # Transformation
     # --------------
 
-    def _transformBy(
-        self, matrix: AffineTransformationLike, **kwargs: Any
-    ) -> None:
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any) -> None:
         r"""Transform the native point.
 
         This is the environment implementation of :meth:`BasePoint.transformBy`.

--- a/Lib/fontParts/base/point.py
+++ b/Lib/fontParts/base/point.py
@@ -15,8 +15,8 @@ from fontParts.base.base import (
 from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedPoint, RemovedPoint
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     QuintupleType,
-    SextupleCollectionType,
     IntFloatType,
 )
 
@@ -565,7 +565,7 @@ class BasePoint(
     # --------------
 
     def _transformBy(
-        self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any
+        self, matrix: AffineTransformationLike, **kwargs: Any
     ) -> None:
         r"""Transform the native point.
 

--- a/Lib/fontParts/base/segment.py
+++ b/Lib/fontParts/base/segment.py
@@ -15,8 +15,8 @@ from fontParts.base import normalizers
 from fontParts.base.deprecated import DeprecatedSegment, RemovedSegment
 from fontParts.base.compatibility import SegmentCompatibilityReporter
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     CollectionType,
-    SextupleCollectionType,
     IntFloatType,
 )
 
@@ -591,7 +591,7 @@ class BaseSegment(
     # Transformation
     # --------------
 
-    def _transformBy(self, matrix: SextupleCollectionType[IntFloatType], **kwargs: Any):
+    def _transformBy(self, matrix: AffineTransformationLike, **kwargs: Any):
         r"""Transform the native object according to the given matrix.
 
         This is the environment implementation of :meth:`TransformationMixin.transformBy`.

--- a/Lib/fontParts/fontshell/anchor.py
+++ b/Lib/fontParts/fontshell/anchor.py
@@ -4,8 +4,8 @@ from typing import Optional
 import defcon
 from fontParts.base import BaseAnchor
 from fontParts.base.annotations import (
-    QuadrupleType,
-    QuadrupleCollectionType,
+    RGBALike,
+    RGBA,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject
@@ -67,11 +67,11 @@ class RAnchor(RBaseObject, BaseAnchor):
 
     # color
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/anchor.py
+++ b/Lib/fontParts/fontshell/anchor.py
@@ -3,11 +3,7 @@ from typing import Optional
 
 import defcon
 from fontParts.base import BaseAnchor
-from fontParts.base.annotations import (
-    RGBALike,
-    RGBA,
-    IntFloatType,
-)
+from fontParts.base.annotations import RGBALike, RGBA, IntFloatType
 from fontParts.fontshell.base import RBaseObject
 
 

--- a/Lib/fontParts/fontshell/component.py
+++ b/Lib/fontParts/fontshell/component.py
@@ -4,8 +4,8 @@ from typing import Optional, Type
 import defcon
 from fontParts.base import BaseComponent
 from fontParts.base.annotations import (
-    SextupleType,
-    SextupleCollectionType,
+    AffineTransformationLike,
+    AffineTransformation,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject
@@ -31,13 +31,13 @@ class RComponent(RBaseObject, BaseComponent):
 
     # transformation
 
-    def _get_transformation(self) -> SextupleType[float]:
+    def _get_transformation(self) -> AffineTransformation:
         component = self.naked()
         if component is None:
             raise ValueError("Component cannot be None.")
         return component.transformation
 
-    def _set_transformation(self, value: SextupleCollectionType[IntFloatType]) -> None:
+    def _set_transformation(self, value: AffineTransformationLike) -> None:
         component = self.naked()
         if component is not None:
             component.transformation = value

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Optional, Any
 import defcon
 from fontParts.base import BaseContour
 from fontParts.base.annotations import (
+    BoundingBox,
     Coordinate,
     CoordinateLike,
     QuadrupleType,
@@ -61,7 +62,7 @@ class RContour(RBaseObject, BaseContour):
     # Bounds
     # ------
 
-    def _get_bounds(self) -> QuadrupleType[float] | None:
+    def _get_bounds(self) -> BoundingBox | None:
         return self.naked().bounds
 
     # ----

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -7,7 +7,6 @@ from fontParts.base.annotations import (
     BoundingBox,
     Coordinate,
     CoordinateLike,
-    QuadrupleType,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject

--- a/Lib/fontParts/fontshell/contour.py
+++ b/Lib/fontParts/fontshell/contour.py
@@ -3,7 +3,12 @@ from typing import TYPE_CHECKING, Optional, Any
 
 import defcon
 from fontParts.base import BaseContour
-from fontParts.base.annotations import PairCollectionType, QuadrupleType, IntFloatType
+from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
+    QuadrupleType,
+    IntFloatType,
+)
 from fontParts.fontshell.base import RBaseObject
 from fontParts.fontshell.point import RPoint
 from fontParts.fontshell.segment import RSegment
@@ -80,7 +85,7 @@ class RContour(RBaseObject, BaseContour):
     # Point and Contour Inside
     # ------------------------
 
-    def _pointInside(self, point: PairCollectionType[IntFloatType]) -> bool:
+    def _pointInside(self, point: CoordinateLike) -> bool:
         return self.naked().pointInside(point)
 
     def _contourInside(self, otherContour: BaseContour) -> bool:
@@ -101,7 +106,7 @@ class RContour(RBaseObject, BaseContour):
     def _insertPoint(
         self,
         index: int,
-        position: PairCollectionType[IntFloatType],
+        position: CoordinateLike,
         type: str | None = None,
         smooth: bool | None = None,
         name: str | None = None,

--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -143,12 +143,7 @@ class RFont(RBaseObject, BaseFont):
 
     # new
 
-    def _newLayer(
-        self,
-        name: str,
-        color: RGBALike | None,
-        **kwargs: Any,
-    ) -> RLayer:
+    def _newLayer(self, name: str, color: RGBALike | None, **kwargs: Any) -> RLayer:
         layers = self.naked().layers
         layer = layers.newLayer(name)
         layer.color = color

--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -4,10 +4,11 @@ import os
 
 import defcon
 from fontParts.base.annotations import (
+    RGBALike,
+    RGBA,
     Coordinate,
     CoordinateLike,
     CollectionType,
-    QuadrupleCollectionType,
     IntFloatType,
 )
 from fontParts.base import BaseFont
@@ -145,7 +146,7 @@ class RFont(RBaseObject, BaseFont):
     def _newLayer(
         self,
         name: str,
-        color: QuadrupleCollectionType[IntFloatType] | None,
+        color: RGBALike | None,
         **kwargs: Any,
     ) -> RLayer:
         layers = self.naked().layers
@@ -185,7 +186,7 @@ class RFont(RBaseObject, BaseFont):
         position: CoordinateLike,
         angle: float | None,
         name: str | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         identifier: str | None = None,
         **kwargs: Any,
     ) -> RGuideline:

--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -4,8 +4,9 @@ import os
 
 import defcon
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     CollectionType,
-    PairCollectionType,
     QuadrupleCollectionType,
     IntFloatType,
 )
@@ -181,7 +182,7 @@ class RFont(RBaseObject, BaseFont):
 
     def _appendGuideline(
         self,
-        position: PairCollectionType[IntFloatType],
+        position: CoordinateLike,
         angle: float | None,
         name: str | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -5,12 +5,12 @@ import defcon
 import booleanOperations
 from fontParts.base import BaseGlyph
 from fontParts.base.annotations import (
+    RGBALike,
+    RGBA,
     BoundingBox,
     Coordinate,
     CoordinateLike,
     CollectionType,
-    QuadrupleType,
-    QuadrupleCollectionType,
     SextupleCollectionType,
     IntFloatType,
 )
@@ -198,7 +198,7 @@ class RGlyph(RBaseObject, BaseGlyph):
         self,
         name: str,
         position: CoordinateLike | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         identifier: str | None = None,
         **kwargs: Any,
     ) -> RAnchor:
@@ -236,7 +236,7 @@ class RGlyph(RBaseObject, BaseGlyph):
         position: CoordinateLike | None,
         angle: float,
         name: str | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
         identifier: str | None = None,
         **kwargs: Any,
     ) -> RGuideline:
@@ -299,7 +299,7 @@ class RGlyph(RBaseObject, BaseGlyph):
         self,
         data: bytes,
         transformation: SextupleCollectionType[IntFloatType] | None = None,
-        color: QuadrupleCollectionType[IntFloatType] | None = None,
+        color: RGBALike | None = None,
     ) -> RImage:
         image = self.naked().image
         image = self.imageClass(image)
@@ -318,14 +318,14 @@ class RGlyph(RBaseObject, BaseGlyph):
 
     # Mark
 
-    def _get_markColor(self) -> QuadrupleType[float] | None:
+    def _get_markColor(self) -> RGBA | None:
         value = self.naked().markColor
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_markColor(
-        self, value: QuadrupleCollectionType[IntFloatType] | None
+        self, value: RGBALike | None
     ) -> None:
         self.naked().markColor = value
 

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -5,8 +5,9 @@ import defcon
 import booleanOperations
 from fontParts.base import BaseGlyph
 from fontParts.base.annotations import (
+    Coordinate,
+    CoordinateLike,
     CollectionType,
-    PairCollectionType,
     QuadrupleType,
     QuadrupleCollectionType,
     SextupleCollectionType,
@@ -195,7 +196,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _appendAnchor(
         self,
         name: str,
-        position: PairCollectionType[IntFloatType] | None = None,
+        position: CoordinateLike | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,
         identifier: str | None = None,
         **kwargs: Any,
@@ -231,7 +232,7 @@ class RGlyph(RBaseObject, BaseGlyph):
 
     def _appendGuideline(
         self,
-        position: PairCollectionType[IntFloatType] | None,
+        position: CoordinateLike | None,
         angle: float,
         name: str | None = None,
         color: QuadrupleCollectionType[IntFloatType] | None = None,

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -5,6 +5,7 @@ import defcon
 import booleanOperations
 from fontParts.base import BaseGlyph
 from fontParts.base.annotations import (
+    BoundingBox,
     Coordinate,
     CoordinateLike,
     CollectionType,
@@ -113,7 +114,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     # Bounds
     # ------
 
-    def _get_bounds(self) -> QuadrupleType[float] | None:
+    def _get_bounds(self) -> BoundingBox | None:
         return self.naked().bounds
 
     # ----

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -324,9 +324,7 @@ class RGlyph(RBaseObject, BaseGlyph):
             value = tuple(value)
         return value
 
-    def _set_markColor(
-        self, value: RGBALike | None
-    ) -> None:
+    def _set_markColor(self, value: RGBALike | None) -> None:
         self.naked().markColor = value
 
     # Note

--- a/Lib/fontParts/fontshell/glyph.py
+++ b/Lib/fontParts/fontshell/glyph.py
@@ -5,13 +5,13 @@ import defcon
 import booleanOperations
 from fontParts.base import BaseGlyph
 from fontParts.base.annotations import (
+    AffineTransformationLike,
     RGBALike,
     RGBA,
     BoundingBox,
     Coordinate,
     CoordinateLike,
     CollectionType,
-    SextupleCollectionType,
     IntFloatType,
 )
 from fontParts.base.errors import FontPartsError
@@ -298,7 +298,7 @@ class RGlyph(RBaseObject, BaseGlyph):
     def _addImage(
         self,
         data: bytes,
-        transformation: SextupleCollectionType[IntFloatType] | None = None,
+        transformation: AffineTransformationLike | None = None,
         color: RGBALike | None = None,
     ) -> RImage:
         image = self.naked().image

--- a/Lib/fontParts/fontshell/guideline.py
+++ b/Lib/fontParts/fontshell/guideline.py
@@ -3,11 +3,7 @@ from typing import Optional
 
 import defcon
 from fontParts.base import BaseGuideline
-from fontParts.base.annotations import (
-    RGBALike,
-    RGBA,
-    IntFloatType,
-)
+from fontParts.base.annotations import RGBALike, RGBA, IntFloatType
 from fontParts.fontshell.base import RBaseObject
 
 

--- a/Lib/fontParts/fontshell/guideline.py
+++ b/Lib/fontParts/fontshell/guideline.py
@@ -4,8 +4,8 @@ from typing import Optional
 import defcon
 from fontParts.base import BaseGuideline
 from fontParts.base.annotations import (
-    QuadrupleType,
-    QuadrupleCollectionType,
+    RGBALike,
+    RGBA,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject
@@ -77,11 +77,11 @@ class RGuideline(RBaseObject, BaseGuideline):
 
     # color
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         self.naked().color = value

--- a/Lib/fontParts/fontshell/image.py
+++ b/Lib/fontParts/fontshell/image.py
@@ -5,9 +5,9 @@ import defcon
 from fontTools.ufoLib.validators import pngValidator
 from fontParts.base import BaseImage, FontPartsError
 from fontParts.base.annotations import (
-    QuadrupleType,
+    RGBALike,
+    RGBA,
     SextupleType,
-    QuadrupleCollectionType,
     SextupleCollectionType,
     IntFloatType,
 )
@@ -17,7 +17,7 @@ from fontParts.fontshell.base import RBaseObject
 class RImage(RBaseObject, BaseImage):
     wrapClass = defcon.Image
     _orphanData: bytes | None = None
-    _orphanColor: QuadrupleCollectionType[IntFloatType] | None = None
+    _orphanColor: RGBALike | None = None
 
     # ----------
     # Attributes
@@ -33,7 +33,7 @@ class RImage(RBaseObject, BaseImage):
 
     # Color
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         if self.font is None and self._orphanColor is not None:
             r, g, b, a = self._orphanColor
             return (r, g, b, a)
@@ -42,7 +42,7 @@ class RImage(RBaseObject, BaseImage):
             value = tuple(value)
         return value
 
-    def _set_color(self, value: QuadrupleCollectionType[IntFloatType] | None) -> None:
+    def _set_color(self, value: RGBALike | None) -> None:
         if self.font is None:
             self._orphanColor = value
         else:

--- a/Lib/fontParts/fontshell/image.py
+++ b/Lib/fontParts/fontshell/image.py
@@ -5,10 +5,10 @@ import defcon
 from fontTools.ufoLib.validators import pngValidator
 from fontParts.base import BaseImage, FontPartsError
 from fontParts.base.annotations import (
+    AffineTransformationLike,
+    AffineTransformation,
     RGBALike,
     RGBA,
-    SextupleType,
-    SextupleCollectionType,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject
@@ -25,10 +25,10 @@ class RImage(RBaseObject, BaseImage):
 
     # Transformation
 
-    def _get_transformation(self) -> SextupleType[float]:
+    def _get_transformation(self) -> AffineTransformation:
         return self.naked().transformation
 
-    def _set_transformation(self, value: SextupleCollectionType[float]) -> None:
+    def _set_transformation(self, value: AffineTransformationLike) -> None:
         self.naked().transformation = value
 
     # Color

--- a/Lib/fontParts/fontshell/kerning.py
+++ b/Lib/fontParts/fontshell/kerning.py
@@ -26,7 +26,5 @@ class RKerning(RBaseObject, BaseKerning):
     def _delItem(self, key: str) -> None:
         del self.naked()[key]
 
-    def _find(
-        self, pair: KerningPairLike, default: int | float | None = 0
-    ) -> int:
+    def _find(self, pair: KerningPairLike, default: int | float | None = 0) -> int:
         return self.naked().find(pair, default)

--- a/Lib/fontParts/fontshell/kerning.py
+++ b/Lib/fontParts/fontshell/kerning.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Union
 from collections.abc import ItemsView
 
 import defcon
-from fontParts.base.annotations import KerningPairLike, PairCollectionType
+from fontParts.base.annotations import KerningPairLike
 from fontParts.base import BaseKerning
 from fontParts.fontshell.base import RBaseObject
 

--- a/Lib/fontParts/fontshell/kerning.py
+++ b/Lib/fontParts/fontshell/kerning.py
@@ -3,7 +3,7 @@ from typing import Any, Optional, Union
 from collections.abc import ItemsView
 
 import defcon
-from fontParts.base.annotations import PairCollectionType
+from fontParts.base.annotations import KerningPairLike, PairCollectionType
 from fontParts.base import BaseKerning
 from fontParts.fontshell.base import RBaseObject
 
@@ -27,6 +27,6 @@ class RKerning(RBaseObject, BaseKerning):
         del self.naked()[key]
 
     def _find(
-        self, pair: PairCollectionType[str], default: int | float | None = 0
+        self, pair: KerningPairLike, default: int | float | None = 0
     ) -> int:
         return self.naked().find(pair, default)

--- a/Lib/fontParts/fontshell/layer.py
+++ b/Lib/fontParts/fontshell/layer.py
@@ -3,11 +3,7 @@ from typing import TYPE_CHECKING, Optional, Tuple, Dict, Any
 
 import defcon
 from fontParts.base import BaseLayer
-from fontParts.base.annotations import (
-    RGBALike,
-    RGBA,
-    IntFloatType,
-)
+from fontParts.base.annotations import RGBALike, RGBA, IntFloatType
 from fontParts.fontshell.base import RBaseObject
 from fontParts.fontshell.lib import RLib
 from fontParts.fontshell.glyph import RGlyph
@@ -55,9 +51,7 @@ class RLayer(RBaseObject, BaseLayer):
             value = tuple(value)
         return value
 
-    def _set_color(
-        self, value: RGBALike | None, **kwargs: Any
-    ) -> None:
+    def _set_color(self, value: RGBALike | None, **kwargs: Any) -> None:
         self.naked().color = value
 
     # -----------------

--- a/Lib/fontParts/fontshell/layer.py
+++ b/Lib/fontParts/fontshell/layer.py
@@ -4,8 +4,8 @@ from typing import TYPE_CHECKING, Optional, Tuple, Dict, Any
 import defcon
 from fontParts.base import BaseLayer
 from fontParts.base.annotations import (
-    QuadrupleCollectionType,
-    QuadrupleType,
+    RGBALike,
+    RGBA,
     IntFloatType,
 )
 from fontParts.fontshell.base import RBaseObject
@@ -49,14 +49,14 @@ class RLayer(RBaseObject, BaseLayer):
 
     # color
 
-    def _get_color(self) -> QuadrupleType[float] | None:
+    def _get_color(self) -> RGBA | None:
         value = self.naked().color
         if value is not None:
             value = tuple(value)
         return value
 
     def _set_color(
-        self, value: QuadrupleCollectionType[IntFloatType] | None, **kwargs: Any
+        self, value: RGBALike | None, **kwargs: Any
     ) -> None:
         self.naked().color = value
 

--- a/Lib/fontParts/test/test_component.py
+++ b/Lib/fontParts/test/test_component.py
@@ -1,5 +1,6 @@
-import unittest
 import collections
+import unittest
+
 from fontParts.base import FontPartsError
 
 
@@ -607,7 +608,7 @@ class TestComponent(unittest.TestCase):
         pointPen = DigestPointPen()
         glyph.drawPoints(pointPen)
         expected = (
-            ("beginPath", None),
+            "beginPath",
             ((0, 0), "line", False, "point 0"),
             ((0, 100), "line", False, "point 1"),
             ((100, 100), "line", False, "point 2"),
@@ -641,7 +642,7 @@ class TestComponent(unittest.TestCase):
         pointPen = DigestPointPen()
         glyph.drawPoints(pointPen)
         expected = (
-            ("beginPath", None),
+            "beginPath",
             ((0, 0), "line", False, "point 0"),
             ((0, 200), "line", False, "point 1"),
             ((200, 200), "line", False, "point 2"),


### PR DESCRIPTION
Alright, here's the last PR from my end. With @typemytype we discussed the possibility to change the names of some of the aliases from describing their shape (here we need two numbers), to describing their domain (here we need a scale factor). We used the same approach for [DrawBot](https://github.com/typemytype/drawbot/blob/master/drawBot/aliases.py) a while ago. We believe it pairs well with the code they're immersed into (`value: BoundingBox` vs `value: SextupleType[float]`). The shape information is handled by pyright or mypy to flag errors in the IDE, and usually accessible through interactive docs. This change also renders the use of generics redundant while hinting the code.

Before:

```python3

T = TypeVar("T")
IntFloatType = int | float

PairType = tuple[T, T]
PairCollectionType = list[T] | PairType[T]

TransformationType = IntFloatType | list[IntFloatType] | PairType[IntFloatType]

def scaleBy(
    self,
    value: TransformationType,
    origin: PairCollectionType[IntFloatType] | None = None,
) -> None: ...

def _scaleBy(
    self,
    value: PairCollectionType[IntFloatType],
    origin: PairCollectionType[IntFloatType],
    **kwargs: Any,
) -> None: ...
```

After:

```python3
IntFloatType = int | float
ScaleFactor = tuple[float, float]
ScaleFactorPair = list[IntFloatType] | ScaleFactor
ScaleFactorLike = IntFloatType | ScaleFactorPair
Coordinate = tuple[IntFloatType, IntFloatType]
CoordinateLike = list[IntFloatType] | Coordinate

def scaleBy(
    self,
    value: ScaleFactorLike,
    origin: CoordinateLike | None = None,
) -> None: ...

def _scaleBy(
    self,
    value: ScaleFactorPair,
    origin: CoordinateLike,
    **kwargs: Any,
) -> None: ...
```

New aliases have `*Like` versions (inspired by `os.PathLike`) for loose inputs (list + tuple) and, in the case of Scale/Interpolation/Skew, also a `*Pair` option when a scalar is not admitted.

I've added: `Coordinate`, `BoundingBox`, `RGBA`, `AffineTransformation`, `KerningPair`, `ScaleFactor`, `SkewAngle`, `InterpolationFactor` and removed: `PairType`, `QuadrupleType`, `QuintupleType`, `SextupleType`, `*CollectionType` variants, `TransformationType`.

While at it, I've fixed the typing of the kerning dict. I've realized that, counterintuitively, it accepts "loose" input for its methods (and dunder methods). In case you're wondering what I am talking about, `font.kerning[["A", "B"]]` is totally fine in fontParts 😅. So I've adjusted the hints accordingly.

I know this seems quite a large change, and it is in terms of LOC, but from a functional standpoint, it's just the same. Just a different flavor of sugar I'd say. Happy to hear your thoughts about this.