### PR TITLE
Fix `dynamicProperty` name arguments

### DIFF
--- a/Lib/fontParts/base/contour.py
+++ b/Lib/fontParts/base/contour.py
@@ -761,7 +761,7 @@ class BaseContour(
     # ---------------
 
     bounds: dynamicProperty = dynamicProperty(
-        "bounds",
+        "base_bounds",
         """Get the bounds of the contour.
 
         This property is read-only.
@@ -809,7 +809,7 @@ class BaseContour(
         return pen.bounds
 
     area: dynamicProperty = dynamicProperty(
-        "area",
+        "base_area",
         """Get the area of the contour
 
         This property is read-only.

--- a/Lib/fontParts/base/glyph.py
+++ b/Lib/fontParts/base/glyph.py
@@ -2976,7 +2976,7 @@ class BaseGlyph(
         return pen.getResult()
 
     bounds: dynamicProperty = dynamicProperty(
-        "bounds",
+        "base_bounds",
         """Get the bounds of the glyph.
 
         This property is read-only.
@@ -3021,7 +3021,7 @@ class BaseGlyph(
         return pen.bounds
 
     area: dynamicProperty = dynamicProperty(
-        "area",
+        "base_area",
         """Get the area of the glyph
 
         This property is read-only.

--- a/Lib/fontParts/base/image.py
+++ b/Lib/fontParts/base/image.py
@@ -411,7 +411,7 @@ class BaseImage(
     # Data
 
     data: dynamicProperty = dynamicProperty(
-        "data",
+        "base_data",
         """Get or set the image's raw byte data.
         
         The possible formats are defined by each environment.


### PR DESCRIPTION
Fixes a few instances of environment implementation getters/setters being passed directly to `dynamicProperty`, bypassing `_base` methods.