### PR TITLE
Include `os.PathLike` when typing path parameters

### DIFF
--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -405,7 +405,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return formatToExtension.get(format, fallbackFormat)
 
     def generate(
-        self, format: str, path: str | None = None, **environmentOptions: Any
+        self, format: str, path: str | os.PathLike | None = None, **environmentOptions: Any
     ) -> None:
         r"""Generate the font in another format.
 
@@ -501,7 +501,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
         return False
 
     def _generate(
-        self, format: str, path: str | None, environmentOptions: dict, **kwargs: object
+        self, format: str, path: str | os.PathLike | None, environmentOptions: dict, **kwargs: object
     ) -> None:
         """Generate the native font in another format.
 

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -54,7 +54,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
     """
 
     def __init__(
-        self, pathOrObject: str | BaseFont | None = None, showInterface: bool = True
+        self, pathOrObject: str | os.PathLike | BaseFont | None = None, showInterface: bool = True
     ) -> None:
         super().__init__(pathOrObject=pathOrObject, showInterface=showInterface)
 
@@ -221,7 +221,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def save(
         self,
-        path: str | None = None,
+        path: str | os.PathLike | None = None,
         showProgress: bool = False,
         formatVersion: int | None = None,
         fileStructure: str | None = None,
@@ -285,7 +285,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
 
     def _save(
         self,
-        path: str | None,
+        path: str | os.PathLike | None,
         showProgress: bool,
         formatVersion: int | None,
         fileStructure: str | None,

--- a/Lib/fontParts/base/font.py
+++ b/Lib/fontParts/base/font.py
@@ -463,7 +463,7 @@ class BaseFont(_BaseGlyphVendor, InterpolationMixin, DeprecatedFont, RemovedFont
                 "The file cannot be generated because an output path was not defined."
             )
         elif path is None:
-            path = os.path.splitext(self.path)[0]
+            path = os.path.splitext(os.fsdecode(self.path))[0]
             path += ext
         elif os.path.isdir(path):
             if self.path is None:

--- a/Lib/fontParts/base/normalizers.py
+++ b/Lib/fontParts/base/normalizers.py
@@ -5,6 +5,7 @@ from collections import Counter
 from fontTools.misc.fixedTools import otRound
 from pathlib import Path
 import datetime
+import os
 
 from fontParts.base.annotations import (
     InterpolationFactorLike,
@@ -1164,7 +1165,7 @@ def normalizeGlyphNote(value: str) -> str:
 # File Path
 
 
-def normalizeFilePath(value: str | Path) -> str:
+def normalizeFilePath(value: str | os.PathLike) -> str:
     """Normalize a file path.
 
     :param value: The file path to normalize as a :class:`str` or :class:`pathlib.Path`.

--- a/Lib/fontParts/fontshell/font.py
+++ b/Lib/fontParts/fontshell/font.py
@@ -55,7 +55,7 @@ class RFont(RBaseObject, BaseFont):
 
     def _save(
         self,
-        path: str | None = None,
+        path: str | os.PathLike | None = None,
         showProgress: bool = False,
         formatVersion: int | None = None,
         fileStructure: str | None = None,


### PR DESCRIPTION
In order to pass `pathlib.Path` objects to the `__init__` and `save` methods of font objects, this PR adds `os.PathLike` to the type hints of path parameters.

Currently, only `RFont._init` types `pathOrObject` this way, which means it isn't picked up by static type checkers when initializing objects.